### PR TITLE
Avoid "statement is unreachable" compile errors in async_reduce.cu test

### DIFF
--- a/testing/async_reduce.cu
+++ b/testing/async_reduce.cu
@@ -973,6 +973,7 @@ struct test_async_reduce_allocator_on_then_after
     );
 
     KNOWN_FAILURE;
+#if 0
     // FIXME: The below fails because you can't combine allocator attachment,
     // `.on`, and `.after`.
     ASSERT_EQUAL_QUIET(stream1, f2.stream().native_handle());
@@ -986,6 +987,7 @@ struct test_async_reduce_allocator_on_then_after
 
     thrust::cuda_cub::throw_on_error(cudaStreamDestroy(stream0));
     thrust::cuda_cub::throw_on_error(cudaStreamDestroy(stream1));
+#endif
   }
 };
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(


### PR DESCRIPTION
Test test_async_reduce_allocator_on_then_after in async_reduce.cu has
"KNOWN_FAILURE;" in the middle of a code block.  This results in "statement is
unreachable" compiler errors from NVC++ on the following line.

```
"/proj/cuda/thrust/main/testing/async_reduce.cu", line 978: error: statement is
          unreachable
      ASSERT_EQUAL_QUIET(stream1, f2.stream().native_handle());
      ^
          detected during:
            instantiation of "void unittest::for_each_type<TypeList, Function,
                      T, i>::operator()(U) [with TypeList=NumericTypes,
                      Function=test_async_reduce_allocator_on_then_after,
                      T=char, i=0U, U=size_t]" at line 537 of
                      "/proj/cuda/thrust/main/testing/unittest/testframework.h"
            instantiation of "void VariableUnitTest<TestName, TypeList>::run()
                      [with TestName=test_async_reduce_allocator_on_then_after,
                      TypeList=NumericTypes]"
```

The compiler error is correct.  KNOWN_FAILURE expands to a throw expression,
so everything after it is dead code.

Fix the problem by putting everything after KNOWN_FAILURE in a "#if 0" block.