### PR TITLE
Replace test script var THRUST_DIR with THRUST_ROOT.

### DIFF
--- a/examples/cmake/CMakeLists.txt
+++ b/examples/cmake/CMakeLists.txt
@@ -6,9 +6,10 @@ if (THRUST_CPP_FOUND AND THRUST_CUDA_FOUND)
     NAME thrust.example.cmake.add_subdir
     COMMAND "${CMAKE_COMMAND}"
       --log-level=VERBOSE
+      -G "${CMAKE_GENERATOR}"
       -S "${CMAKE_CURRENT_SOURCE_DIR}/add_subdir"
       -B "${CMAKE_CURRENT_BINARY_DIR}/add_subdir"
-      -D "THRUST_DIR=${Thrust_SOURCE_DIR}"
+      -D "THRUST_ROOT=${Thrust_SOURCE_DIR}"
       -D "CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
       -D "CMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER}"
       -D "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"

--- a/examples/cmake/add_subdir/CMakeLists.txt
+++ b/examples/cmake/add_subdir/CMakeLists.txt
@@ -29,7 +29,7 @@ set(THRUST_OPTIONAL_SYSTEMS CUDA)
 
 # Use your project's checkout of Thrust here, for most cases
 # `add_subdirectory(thrust)` will be sufficient.
-add_subdirectory("${THRUST_DIR}" thrust)
+add_subdirectory("${THRUST_ROOT}" thrust)
 
 # Create a thrust target that only uses the serial CPP backend.
 # See thrust/thrust/cmake/README.md for details and additional options:


### PR DESCRIPTION
An internal find_package call sets THRUST_DIR in the CMake cache,
which can cause unexpected behavior during subsequent tests.

Also pass the CMake generator to the test project. This is especially
important on windows.

Update CUB submodule to bring in `add_subdirectory` support as well.