### PR TITLE
cmake: option to install thrust when used via add_subdirectory()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,3 @@
-# Support adding Thrust to a parent project via add_subdirectory.
-# See examples/cmake/add_subdir/CMakeLists.txt for details.
-if (NOT "${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}")
-  include(cmake/ThrustAddSubdir.cmake)
-  return()
-endif()
-
 # 3.15 is the minimum.
 # 3.17 for nvc++/Feta
 # 3.18 for C++17 + CUDA
@@ -18,12 +11,31 @@ endif()
 
 project(Thrust NONE)
 
+# Determine whether Thrust is the top-level project or included into
+# another project via add_subdirectory()
+if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}")
+  set(THRUST_TOPLEVEL_PROJECT ON)
+else()
+  set(THRUST_TOPLEVEL_PROJECT OFF)
+endif()
+
+option(THRUST_ENABLE_INSTALL_RULES "Enable installation of Thrust" ${THRUST_TOPLEVEL_PROJECT})
+if (THRUST_ENABLE_INSTALL_RULES)
+  include(cmake/ThrustInstallRules.cmake)
+endif()
+
+# Support adding Thrust to a parent project via add_subdirectory.
+# See examples/cmake/add_subdir/CMakeLists.txt for details.
+if (NOT THRUST_TOPLEVEL_PROJECT)
+  include(cmake/ThrustAddSubdir.cmake)
+  return()
+endif()
+
 include(cmake/AppendOptionIfAvailable.cmake)
 
 include(cmake/ThrustBuildCompilerTargets.cmake)
 include(cmake/ThrustBuildTargetList.cmake)
 include(cmake/ThrustMultiConfig.cmake)
-include(cmake/ThrustInstallRules.cmake)
 include(cmake/ThrustUtilities.cmake)
 
 option(THRUST_ENABLE_HEADER_TESTING "Test that all public headers compile." "ON")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,6 +336,8 @@ The CMake options are divided into these categories:
 - `THRUST_ENABLE_EXAMPLE_FILECHECK={ON, OFF}`
   - Enable validation of example outputs using the LLVM FileCheck utility.
     Default is `OFF`.
+- `THRUST_ENABLE_INSTALL_RULES={ON, OFF}`
+  - If true, installation rules will be generated for thrust. Default is `ON`.
 
 ## Single Config CMake Options
 
@@ -391,6 +393,10 @@ The CMake options are divided into these categories:
     simultaneously.
   - CUB configurations will be generated for each C++ dialect targeted by
     the current Thrust build.
+- `THRUST_INSTALL_CUB_HEADERS={ON, OFF}`
+  - If enabled, the CUB project's headers will be installed through Thrust's
+    installation rules. Default is `ON`.
+  - This option depends on `THRUST_ENABLE_INSTALL_RULES`.
 - `THRUST_ENABLE_COMPUTE_XX={ON, OFF}`
   - Controls the targeted CUDA architecture(s)
   - Multiple options may be selected when using NVCC as the CUDA compiler.


### PR DESCRIPTION
This is about the case where a downstream library pulls in Thrust via `add_subdirectory()`. In this case, when the library is installed, it may want to also install Thrust together with it, as it's presumably needed to use the library (in particular, if the library's public header include thrust headers.)

This PR adds an option `THRUST_INSTALL` to Thrust. The default install behavior is unchanged, ie., when Thrust is built stand-alone, it will be installed on `make install`, and when Thrust is pulled in via `add_subdirectory()`, it won't install itself. But in the case described above, the downstream project can `set(THRUST_INSTALL ON)` before the `add_subdirectory()` so that the downstream library's install will contain Thrust.
