### PR TITLE
cmake: print status message if Thrust is found

### DIFF
--- a/thrust/cmake/thrust-config.cmake
+++ b/thrust/cmake/thrust-config.cmake
@@ -650,3 +650,9 @@ foreach(component ${${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS})
 endforeach()
 
 thrust_update_system_found_flags()
+
+include(FindPackageHandleStandardArgs)
+if (NOT Thrust_CONFIG)
+  set(Thrust_CONFIG "${CMAKE_CURRENT_LIST_FILE}")
+endif()
+find_package_handle_standard_args(Thrust CONFIG_MODE)


### PR DESCRIPTION
Here's a minor improvement to the cmake config that's installed with Thrust:

If using `find_package(Thrust 1.10.0)` is successful, it'll print something like

```
-- Found Thrust: /root/src/thrust/build/install/include/thrust/cmake/thrust-config.cmake (found suitable version "1.11.0.0", minimum required is "1.10.0")
```

rather than being silent about it.

