### PR TITLE
defines thrust::tuple_element consistently with std::tuple_element

### DIFF
--- a/thrust/detail/tuple.inl
+++ b/thrust/detail/tuple.inl
@@ -51,7 +51,7 @@ template <
 class tuple;
 
 // forward declaration of tuple_element
-template<int i, typename T> struct tuple_element;
+template<size_t N, class T> struct tuple_element;
 
 // specializations for tuple_element
 template<class T>
@@ -60,7 +60,7 @@ template<class T>
   typedef typename T::head_type type;
 }; // end tuple_element<0,T>
 
-template<int N, class T>
+template<size_t N, class T>
   struct tuple_element<N, const T>
 {
   private:

--- a/thrust/pair.h
+++ b/thrust/pair.h
@@ -228,7 +228,7 @@ template <typename T1, typename T2>
  *  \tparam N This parameter selects the member of interest.
  *  \tparam T A \c pair type of interest.
  */
-template<int N, typename T> struct tuple_element;
+template<size_t N, class T> struct tuple_element;
 
 
 /*! This convenience metafunction is included for compatibility with

--- a/thrust/tuple.h
+++ b/thrust/tuple.h
@@ -62,7 +62,7 @@ struct null_type;
  *  \see pair
  *  \see tuple
  */
-template<int N, class T>
+template<size_t N, class T>
   struct tuple_element
 {
   private:


### PR DESCRIPTION
I propose changing the template arguments of `thrust::tuple_element` to match `std::tuple_element`:
```
template< std::size_t I, class T >
class tuple_element;
```
This is consistent with [the implementation used by `<cuda/std/tuple>`](https://github.com/NVIDIA/libcudacxx/blob/a6ee80b05f768a61c6a6dfffaa52dc2ed1cd6c6b/libcxx/include/tuple#L101)

While I understand that `thrust::tuple_element` will likely be replaced alongside `thrust::tuple` pending resolution of #1212, the motivation for this PR is that the overload of `thrust::tuple_element` for `thrust::pair` will also need to be replaced, since it still uses `template<int, typename>`.  This PR enables branches such as my [variadic tuple branch](https://github.com/andrewcorrigan/thrust/tree/variadic-2020) to BJHVT (bring-jared-hoberock's-variadic-tuple) while we await mainline variadic `thrust::tuple` support. 



With `-DTHRUST_DEVICE_SYSTEM=CPP`:
```
100% tests passed, 0 tests failed out of 151

Total Test time (real) = 109.05 sec
```