### PR TITLE
cross_system_copy_n: Dont attempt a copy if we're tyring to copy 0 elements

### DIFF
--- a/testing/vector.cu
+++ b/testing/vector.cu
@@ -645,6 +645,19 @@ DECLARE_VECTOR_UNITTEST(TestVectorReserving)
 
 
 template <class Vector>
+void TestVectorUninitialisedCopy(void)
+{
+    thrust::device_vector<int> v;
+    std::vector<int> std_vector;
+
+    v = std_vector;
+
+    ASSERT_EQUAL(v.size(), static_cast<size_t>(0));
+}
+DECLARE_VECTOR_UNITTEST(TestVectorUninitialisedCopy);
+
+
+template <class Vector>
 void TestVectorShrinkToFit(void)
 {
     typedef typename Vector::value_type T;

--- a/thrust/system/cuda/detail/internal/copy_cross_system.h
+++ b/thrust/system/cuda/detail/internal/copy_cross_system.h
@@ -100,12 +100,13 @@ namespace __copy {
 
   {
     typedef typename iterator_traits<InputIt>::value_type InputTy;
-
-    trivial_device_copy(derived_cast(sys1),
-                        derived_cast(sys2),
-                        reinterpret_cast<InputTy*>(thrust::raw_pointer_cast(&*result)),
-                        reinterpret_cast<InputTy const*>(thrust::raw_pointer_cast(&*begin)),
-                        n);
+    if (n > 0) {
+      trivial_device_copy(derived_cast(sys1),
+                          derived_cast(sys2),
+                          reinterpret_cast<InputTy*>(thrust::raw_pointer_cast(&*result)),
+                          reinterpret_cast<InputTy const*>(thrust::raw_pointer_cast(&*begin)),
+                          n);
+    }
 
     return result + n;
   }


### PR DESCRIPTION
Attempting to perform this copy with 0 elements caused a debug assertion when compiling with MSVC in debug mode.

Fixes #1275