### PR TITLE
Fix regression in transform_inclusive_scan.

### DIFF
--- a/thrust/system/cuda/detail/transform_scan.h
+++ b/thrust/system/cuda/detail/transform_scan.h
@@ -50,7 +50,7 @@ transform_inclusive_scan(execution_policy<Derived> &policy,
                          TransformOp                transform_op,
                          ScanOp                     scan_op)
 {
-  // Use the input iterator's value type per https://wg21.link/P0571
+  // Use the transformed input iterator's value type per https://wg21.link/P0571
   using input_type = typename thrust::iterator_value<InputIt>::type;
 #if THRUST_CPP_DIALECT < 2017
   using result_type = typename std::result_of<TransformOp(input_type)>::type;
@@ -58,9 +58,11 @@ transform_inclusive_scan(execution_policy<Derived> &policy,
   using result_type = std::invoke_result_t<TransformOp, input_type>;
 #endif
 
+  using value_type = typename std::remove_reference<result_type>::type;
+
   typedef typename iterator_traits<InputIt>::difference_type size_type;
   size_type num_items = static_cast<size_type>(thrust::distance(first, last));
-  typedef transform_input_iterator_t<result_type,
+  typedef transform_input_iterator_t<value_type,
                                      InputIt,
                                      TransformOp>
       transformed_iterator_t;
@@ -88,7 +90,7 @@ transform_exclusive_scan(execution_policy<Derived> &policy,
                          ScanOp                     scan_op)
 {
   // Use the initial value type per https://wg21.link/P0571
-  using result_type = InitialValueType;
+  using result_type = typename std::remove_reference<InitialValueType>::type;
 
   typedef typename iterator_traits<InputIt>::difference_type size_type;
   size_type num_items = static_cast<size_type>(thrust::distance(first, last));

--- a/thrust/system/detail/generic/transform_scan.inl
+++ b/thrust/system/detail/generic/transform_scan.inl
@@ -51,10 +51,11 @@ __host__ __device__
   // Use the input iterator's value type per https://wg21.link/P0571
   using InputType = typename thrust::iterator_value<InputIterator>::type;
 #if THRUST_CPP_DIALECT < 2017
-  using ValueType = typename std::result_of<UnaryFunction(InputType)>::type;
+  using ResultType = typename std::result_of<UnaryFunction(InputType)>::type;
 #else
-  using ValueType = std::invoke_result_t<UnaryFunction, InputType>;
+  using ResultType = std::invoke_result_t<UnaryFunction, InputType>;
 #endif
+  using ValueType = typename std::remove_reference<ResultType>::type;
 
   thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _first(first, unary_op);
   thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _last(last, unary_op);
@@ -79,7 +80,7 @@ __host__ __device__
                                           AssociativeOperator binary_op)
 {
   // Use the initial value type per https://wg21.link/P0571
-  using ValueType = InitialValueType;
+  using ValueType = typename std::remove_reference<InitialValueType>::type;
 
   thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _first(first, unary_op);
   thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _last(last, unary_op);


### PR DESCRIPTION
We were deducing a reference type when we needed a value type for the
transform iterator instantition.

Fixes #1332 and adds a regression test.