### PR TITLE
Fix type is_pod trait for GCC 10.2.

### DIFF
--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -131,7 +131,7 @@ template<typename T> struct is_pod
        || __is_pod(T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
 // only use the intrinsic for >= 4.3
-#if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
+#if (__GNUC__ * 100 + __GNUC_MINOR__ >= 403)
        || __is_pod(T)
 #endif // GCC VERSION
 #endif // THRUST_HOST_COMPILER


### PR DESCRIPTION
Currently for `__GNUC__ == 10` and `__GNUC_MINOR__ == 2` second part of condition `(__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)` is `false`. Whole condition expected to be `true`. For that lexicographical comparison is needed. Something with aid like [this](https://github.com/ARM-software/vulkan-sdk/blob/master/include/vulkan/vulkan.h#L33-L34).

Currently it is impossible to construct `thrust::device_vector<S>` from `std::vector<S>`, when host compiler is g++ from GCC 10.2:

    struct S { int i; };
    static_assert(std::is_trivially_destructible_v<S>, "!");
    std::vector<S> u{S{1}, S{2}, S{3}};
    thrust::cuda::vector<S> v{u.cbegin(), u.cend()};

due to wrong SFINAE picking on [this](https://github.com/NVIDIA/thrust/blob/main/thrust/detail/allocator/destroy_range.inl#L134) line (which in fact must be `enable_if_destroy_range_case3`) which result in error starting from `thrust::cuda::vector<S>::~vector` destructor.