### PR TITLE
Qualify calls to make_reverse_iterator

### DIFF
--- a/thrust/system/cuda/detail/reverse.h
+++ b/thrust/system/cuda/detail/reverse.h
@@ -70,8 +70,8 @@ reverse_copy(execution_policy<Derived> &policy,
              ResultIt                   result)
 {
   return cuda_cub::copy(policy,
-                        make_reverse_iterator(last),
-                        make_reverse_iterator(first),
+                        thrust::make_reverse_iterator(last),
+                        thrust::make_reverse_iterator(first),
                         result);
 }
 
@@ -89,7 +89,7 @@ reverse(execution_policy<Derived> &policy,
   ItemsIt mid(first);
   thrust::advance(mid, N / 2);
 
-  cuda_cub::swap_ranges(policy, first, mid, make_reverse_iterator(last));
+  cuda_cub::swap_ranges(policy, first, mid, thrust::make_reverse_iterator(last));
 }
 
 


### PR DESCRIPTION
Unqualified calls to `make_reverse_iterator` would result in ADL ambiguities between `std::make_reverse_iterator` and `thrust::make_reverse_iterator` when compiling in C++14 mode and the iterator argument is a `std::vector<T>::iterator` or other `std` type.  Fix the problem and avoid ADL by changing the call to the qualified name `thrust::make_reverse_iterator`.

This was discovered in a parallel algorithms test suite for NVC++, when we recently changed the test suite to sometimes compile in C++14 mode.  `std::make_reverse_iterator` is new to C++14, so the bug doesn't happen when building in C++11 mode.