### PR TITLE
Add gpuCI GPU testing, automatic GPU detection, and support for more compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<a href='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=gcc,CXX_VER=9,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/'><img src='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=gcc,CXX_VER=9,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/badge/icon'></a>
+
 Thrust: Code at the speed of light
 ==================================
 
@@ -70,6 +72,21 @@ int main(void)
   return 0;
 }
 ```
+
+CI Status
+---------
+
+<a href='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-gpu-build/CXX_TYPE=gcc,CXX_VER=7,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/'><img src='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-gpu-build/CXX_TYPE=gcc,CXX_VER=7,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/badge/icon?subject=NVCC%2011.0%20%2B%20GCC%207%20build%20and%20device%20tests'></a>
+<a href='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=gcc,CXX_VER=9,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/'><img src='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=gcc,CXX_VER=9,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/badge/icon?subject=NVCC%2011.0%20%2B%20GCC%209%20build%20and%20host%20tests'></a>
+<a href='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=gcc,CXX_VER=8,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/'><img src='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=gcc,CXX_VER=8,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/badge/icon?subject=NVCC%2011.0%20%2B%20GCC%208%20build%20and%20host%20tests'></a>
+<a href='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=gcc,CXX_VER=7,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/'><img src='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=gcc,CXX_VER=7,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/badge/icon?subject=NVCC%2011.0%20%2B%20GCC%207%20build%20and%20host%20tests'></a>
+<a href='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=gcc,CXX_VER=6,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/'><img src='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=gcc,CXX_VER=6,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/badge/icon?subject=NVCC%2011.0%20%2B%20GCC%206%20build%20and%20host%20tests'></a>
+<a href='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=gcc,CXX_VER=5,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/'><img src='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=gcc,CXX_VER=5,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/badge/icon?subject=NVCC%2011.0%20%2B%20GCC%205%20build%20and%20host%20tests'></a>
+<a href='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=clang,CXX_VER=9,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/'><img src='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=clang,CXX_VER=9,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/badge/icon?subject=NVCC%2011.0%20%2B%20Clang%209%20build%20and%20host%20tests'></a>
+<a href='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=clang,CXX_VER=8,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/'><img src='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=clang,CXX_VER=8,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/badge/icon?subject=NVCC%2011.0%20%2B%20Clang%208%20build%20and%20host%20tests'></a>
+<a href='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=clang,CXX_VER=7,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/'><img src='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=clang,CXX_VER=7,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/badge/icon?subject=NVCC%2011.0%20%2B%20Clang%207%20build%20and%20host%20tests'></a>
+<a href='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=icc,CXX_VER=latest,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/'><img src='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=icc,CXX_VER=latest,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=cuda,SDK_VER=11.0-devel/badge/icon?subject=NVCC%2011.0%20%2B%20ICC%20build%20and%20host%20tests'></a>
+<a href='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=nvcxx,CXX_VER=20.9,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=nvhpc,SDK_VER=20.9-devel/'><img src='https://gpuci.gpuopenanalytics.com/job/nvidia/job/thrust/job/prb/job/thrust-cpu-build/CXX_TYPE=nvcxx,CXX_VER=20.9,OS_TYPE=ubuntu,OS_VER=20.04,SDK_TYPE=nvhpc,SDK_VER=20.9-devel/badge/icon?subject=NVC%2B%2B%2020.9%20build%20and%20host%20tests'></a>
 
 Releases
 --------

--- a/ci/axis/cpu.yml
+++ b/ci/axis/cpu.yml
@@ -1,9 +1,27 @@
+# Copyright (c) 2018-2020 NVIDIA Corporation
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Released under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+
+SDK_TYPE:
+  - cuda
+  - nvhpc
+
+SDK_VER:
+  - 11.0-devel
+  - 20.9-devel
+
+OS_TYPE:
+  - ubuntu
+
 OS_VER:
-  - ubuntu18.04
+  - 20.04
 
 CXX_TYPE:
-  - gcc
+  - nvcxx
   - clang
+  - gcc
+  - icc
 
 CXX_VER:
   - 5
@@ -12,17 +30,67 @@ CXX_VER:
   - 8
   - 9
   - 10
+  - 20.9
+  - latest
 
 exclude:
-  # Unsupported compiler version
+  # Excludes by `SDK_TYPE`.
+  - CXX_TYPE: gcc
+    SDK_TYPE: nvhpc
   - CXX_TYPE: clang
+    SDK_TYPE: nvhpc
+  - CXX_TYPE: icc
+    SDK_TYPE: nvhpc
+  - CXX_TYPE: nvcxx
+    SDK_TYPE: cuda
+  # Excludes by `SDK_VER`.
+  - SDK_TYPE: cuda
+    SDK_VER: 20.9-devel
+  - SDK_TYPE: nvhpc
+    SDK_VER: 11.0-devel
+  # Excludes by `CXX_VER`.
+  - CXX_TYPE: nvcxx
     CXX_VER: 5
-  # This config is broken in the docker image: https://github.com/NVIDIA/cccl/issues/6
-  - CXX_TYPE: clang
+  - CXX_TYPE: nvcxx
     CXX_VER: 6
-  # Needs newer nvcc in image, https://github.com/NVIDIA/cccl/issues/7
-  - CXX_TYPE: clang
+  - CXX_TYPE: nvcxx
+    CXX_VER: 7
+  - CXX_TYPE: nvcxx
+    CXX_VER: 8
+  - CXX_TYPE: nvcxx
+    CXX_VER: 9
+  - CXX_TYPE: nvcxx
     CXX_VER: 10
-  # Config broken in image: https://github.com/NVIDIA/cccl/issues/8
+  - CXX_TYPE: nvcxx
+    CXX_VER: latest
   - CXX_TYPE: gcc
     CXX_VER: 10
+  - CXX_TYPE: gcc
+    CXX_VER: 20.9
+  - CXX_TYPE: gcc
+    CXX_VER: latest
+  - CXX_TYPE: clang
+    CXX_VER: 5
+  - CXX_TYPE: clang
+    CXX_VER: 6
+  - CXX_TYPE: clang
+    CXX_VER: 10
+  - CXX_TYPE: clang
+    CXX_VER: 20.9
+  - CXX_TYPE: clang
+    CXX_VER: latest
+  - CXX_TYPE: icc
+    CXX_VER: 5
+  - CXX_TYPE: icc
+    CXX_VER: 6
+  - CXX_TYPE: icc
+    CXX_VER: 7
+  - CXX_TYPE: icc
+    CXX_VER: 8
+  - CXX_TYPE: icc
+    CXX_VER: 9
+  - CXX_TYPE: icc
+    CXX_VER: 10
+  - CXX_TYPE: icc
+    CXX_VER: 20.9
+

--- a/ci/axis/gpu.yml
+++ b/ci/axis/gpu.yml
@@ -1,0 +1,23 @@
+# Copyright (c) 2018-2020 NVIDIA Corporation
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Released under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+
+SDK_TYPE:
+  - cuda
+
+SDK_VER:
+  - 11.0-devel
+
+OS_TYPE:
+  - ubuntu
+
+OS_VER:
+  - 20.04
+
+CXX_TYPE:
+  - gcc
+
+CXX_VER:
+  - 7
+

--- a/ci/common/build.bash
+++ b/ci/common/build.bash
@@ -11,9 +11,34 @@
 
 set -e
 
-# Logger function for build status output
-function logger() {
-  echo -e "\n>>>> ${@}\n"
+# append variable value
+# Appends ${value} to ${variable}, adding a space before ${value} if
+# ${variable} is not empty.
+function append {
+  tmp="${!1:+${!1} }${2}"
+  eval "${1}=\${tmp}"
+}
+
+# log args...
+# Prints out ${args[*]} with a gpuCI log prefix and a newline before and after.
+function log() {
+  printf "\n>>>> %s\n\n" "${*}"
+}
+
+# print_with_trailing_blank_line args...
+# Prints ${args[*]} with one blank line following, preserving newlines within
+# ${args[*]} but stripping any preceding ${args[*]}.
+function print_with_trailing_blank_line {
+  printf "%s\n\n" "${*}"
+}
+
+# echo_and_run_timed name args...
+# Echo ${args[@]}, then execute ${args[@]} and report how long it took,
+# including ${name} in the output of the time.
+function echo_and_run_timed {
+  echo "${@:2}"
+  TIMEFORMAT=$'\n'"${1} Time: %lR"
+  time ${@:2}
 }
 
 ################################################################################
@@ -34,83 +59,194 @@ cd ${WORKSPACE}
 mkdir -p build
 cd build
 
+if [[ -z "${CMAKE_BUILD_TYPE}" ]]; then
+  CMAKE_BUILD_TYPE="Release"
+fi
+
+CMAKE_BUILD_FLAGS="--"
+
 # The Docker image sets up `${CXX}` and `${CUDACXX}`.
-CMAKE_FLAGS="-G Ninja -DCMAKE_CXX_COMPILER='${CXX}' -DCMAKE_CUDA_COMPILER='${CUDACXX}'"
+append CMAKE_FLAGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+append CMAKE_FLAGS "-DCMAKE_CUDA_COMPILER='${CUDACXX}'"
 
-if [ "${BUILD_MODE}" == "branch" ]; then
-  # Post-commit build.
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_INCLUDE_CUB_CMAKE=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_ENABLE_MULTICONFIG=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_DIALECT_CPP11=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_IGNORE_DEPRECATED_CPP_11=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_DIALECT_CPP14=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_DIALECT_CPP17=OFF"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_SYSTEM_CPP=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_SYSTEM_TBB=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_SYSTEM_OMP=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_SYSTEM_CUDA=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_WORKLOAD=LARGE"
+if [[ "${CXX_TYPE}" == "nvcxx" ]]; then
+  # NVC++ isn't properly detected by CMake, so we have to tell CMake to ignore
+  # detection and explicit provide the compiler ID. Ninja currently isn't
+  # supported, so we just use makefiles.
+  append CMAKE_FLAGS "-DCMAKE_CUDA_COMPILER_FORCED=ON"
+  append CMAKE_FLAGS "-DCMAKE_CUDA_COMPILER_ID=NVCXX"
+  # Don't stop on build failures.
+  append CMAKE_BUILD_FLAGS "-k"
+  # NVC++ currently uses a lot of memory.
+  PARALLEL_LEVEL=1
 else
-  # Pre-commit build.
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_DISABLE_ARCH_BY_DEFAULT=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_ENABLE_COMPUTE_50=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_ENABLE_COMPUTE_60=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_ENABLE_COMPUTE_70=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_ENABLE_COMPUTE_80=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_INCLUDE_CUB_CMAKE=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_ENABLE_MULTICONFIG=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_DIALECT_CPP11=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_IGNORE_DEPRECATED_CPP_11=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_DIALECT_CPP14=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_DIALECT_CPP17=OFF"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_SYSTEM_CPP=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_SYSTEM_TBB=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_SYSTEM_OMP=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_ENABLE_SYSTEM_CUDA=ON"
-  CMAKE_FLAGS="${CMAKE_FLAGS} -DTHRUST_MULTICONFIG_WORKLOAD=SMALL"
+  if [[ "${CXX_TYPE}" == "icc" ]]; then
+    # Only the latest version of the Intel C++ compiler, which NVCC doesn't
+    # officially support yet, is freely available.
+    append CMAKE_FLAGS "-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler"
+  fi
+  # We're using NVCC so we need to set the host compiler.
+  append CMAKE_FLAGS "-DCMAKE_CXX_COMPILER='${CXX}'"
+  append CMAKE_FLAGS "-G Ninja"
+  # Don't stop on build failures.
+  append CMAKE_BUILD_FLAGS "-k0"
 fi
 
-CMAKE_BUILD_FLAGS="-j${PARALLEL_LEVEL}"
-
-if [ ! -z "${@}" ]; then
-  CMAKE_BUILD_FLAGS="${CMAKE_BUILD_FLAGS} -- ${@}"
+if [[ -n "${PARALLEL_LEVEL}" ]]; then
+  DETERMINE_PARALLELISM_FLAGS="-j ${PARALLEL_LEVEL}"
 fi
 
-CTEST_FLAGS=""
-
-if [ "${BUILD_TYPE}" == "cpu" ]; then
-  CTEST_FLAGS="${CTEST_FLAGS} -E ^cub|^thrust.*cuda"
+# COVERAGE_PLAN options:
+# * Exhaustive
+# * Thorough
+# * Minimal
+if [[ -z "${COVERAGE_PLAN}" ]]; then
+  # `ci/local/build.bash` always sets a coverage plan, so we can assume we're
+  # in gpuCI if one was not set.
+  if [[ "${CXX_TYPE}" == "nvcxx" ]]; then
+    # Today, NVC++ builds take too long to do anything more than Minimal.
+    COVERAGE_PLAN="Minimal"
+  elif [[ "${BUILD_TYPE}" == "cpu" ]] && [[ "${BUILD_MODE}" == "branch" ]]; then
+    # Post-commit CPU CI builds.
+    COVERAGE_PLAN="Exhaustive"
+  elif [[ "${BUILD_TYPE}" == "cpu" ]]; then
+    # Pre-commit CPU CI builds.
+    COVERAGE_PLAN="Thorough"
+  elif [[ "${BUILD_TYPE}" == "gpu" ]]; then
+    # Pre- and post-commit GPU CI builds.
+    COVERAGE_PLAN="Minimal"
+  fi
 fi
 
-if [ ! -z "${@}" ]; then
-  CTEST_FLAGS="${CTEST_FLAGS} -R ^${@}$"
+case "${COVERAGE_PLAN}" in
+  Exhaustive)
+    append CMAKE_FLAGS "-DTHRUST_INCLUDE_CUB_CMAKE=ON"
+    append CMAKE_FLAGS "-DTHRUST_ENABLE_MULTICONFIG=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_DIALECT_CPP11=ON"
+    append CMAKE_FLAGS "-DTHRUST_IGNORE_DEPRECATED_CPP_11=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_DIALECT_CPP14=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_DIALECT_CPP17=OFF"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_SYSTEM_CPP=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_SYSTEM_TBB=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_SYSTEM_OMP=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_SYSTEM_CUDA=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_WORKLOAD=LARGE"
+    ;;
+  Thorough)
+    append CMAKE_FLAGS "-DTHRUST_INCLUDE_CUB_CMAKE=ON"
+    append CMAKE_FLAGS "-DTHRUST_ENABLE_MULTICONFIG=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_DIALECT_CPP11=ON"
+    append CMAKE_FLAGS "-DTHRUST_IGNORE_DEPRECATED_CPP_11=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_DIALECT_CPP14=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_DIALECT_CPP17=OFF"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_SYSTEM_CPP=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_SYSTEM_TBB=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_SYSTEM_OMP=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_SYSTEM_CUDA=ON"
+    append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_WORKLOAD=SMALL"
+    append CMAKE_FLAGS "-DTHRUST_AUTO_DETECT_COMPUTE_ARCHS=ON"
+    if [[ "${CXX_TYPE}" != "nvcxx" ]]; then
+      # NVC++ can currently only target one compute architecture at a time.
+      append CMAKE_FLAGS "-DTHRUST_ENABLE_COMPUTE_50=ON"
+      append CMAKE_FLAGS "-DTHRUST_ENABLE_COMPUTE_60=ON"
+      append CMAKE_FLAGS "-DTHRUST_ENABLE_COMPUTE_70=ON"
+    fi
+    append CMAKE_FLAGS "-DTHRUST_ENABLE_COMPUTE_80=ON"
+    ;;
+  Minimal)
+    append CMAKE_FLAGS "-DTHRUST_INCLUDE_CUB_CMAKE=ON"
+    append CMAKE_FLAGS "-DCUB_ENABLE_THOROUGH_TESTING=OFF"
+    append CMAKE_FLAGS "-DCUB_ENABLE_BENCHMARK_TESTING=OFF"
+    append CMAKE_FLAGS "-DCUB_ENABLE_MINIMAL_TESTING=ON"
+    append CMAKE_FLAGS "-DTHRUST_HOST_SYSTEM=CPP"
+    append CMAKE_FLAGS "-DTHRUST_DEVICE_SYSTEM=CUDA"
+    append CMAKE_FLAGS "-DTHRUST_CPP_DIALECT=14"
+    append CMAKE_FLAGS "-DTHRUST_AUTO_DETECT_COMPUTE_ARCHS=ON"
+    if [[ "${BUILD_TYPE}" == "cpu" ]] && [[ "${CXX_TYPE}" == "nvcxx" ]]; then
+      # If no GPU is automatically detected, NVC++ insists that you explicitly
+      # provide an architecture.
+      # TODO: This logic should really be moved into CMake, but it will be
+      # tricky to do that until CMake officially supports NVC++.
+      append CMAKE_FLAGS "-DTHRUST_ENABLE_COMPUTE_80=ON"
+    fi
+    ;;
+esac
+
+if [[ -n "${@}" ]]; then
+  append CMAKE_BUILD_FLAGS "${@}"
 fi
+
+append CTEST_FLAGS "--output-on-failure"
+
+if [[ "${BUILD_TYPE}" == "cpu" ]]; then
+  append CTEST_FLAGS "-E ^cub|^thrust.*cuda"
+fi
+
+if [[ -n "${@}" ]]; then
+  for arg in "${@}"
+  do
+    append CTEST_FLAGS "-R ^${arg}$"
+  done
+fi
+
+# Export variables so they'll show up in the logs when we report the environment.
+export COVERAGE_PLAN
+export CMAKE_FLAGS
+export CMAKE_BUILD_FLAGS
+export CTEST_FLAGS
 
 ################################################################################
 # ENVIRONMENT - Configure and print out information about the environment.
 ################################################################################
 
-logger "Get environment..."
+log "Determine system topology..."
+
+# Set `${PARALLEL_LEVEL}` if it is unset; otherwise, this just reports the
+# system topology.
+source ${WORKSPACE}/ci/common/determine_build_parallelism.bash ${DETERMINE_PARALLELISM_FLAGS}
+
+log "Get environment..."
+
 env
 
-logger "Check versions..."
-${CXX} --version
-${CUDACXX} --version
+log "Check versions..."
+
+# We use sed and echo below to ensure there is always one and only trailing
+# line following the output from each tool.
+
+${CXX} --version 2>&1 | sed -Ez '$ s/\n*$/\n/'
+
+echo
+
+${CUDACXX} --version 2>&1 | sed -Ez '$ s/\n*$/\n/'
+
+echo
+
+if [[ "${BUILD_TYPE}" == "gpu" ]]; then
+  nvidia-smi 2>&1 | sed -Ez '$ s/\n*$/\n/'
+fi
 
 ################################################################################
 # BUILD - Build Thrust and CUB examples and tests.
 ################################################################################
 
-logger "Configure Thrust and CUB..."
-cmake .. ${CMAKE_FLAGS}
+log "Configure Thrust and CUB..."
 
-logger "Build Thrust and CUB..."
-cmake --build . ${CMAKE_BUILD_FLAGS}
+echo_and_run_timed "Configure" cmake .. ${CMAKE_FLAGS}
+
+log "Build Thrust and CUB..."
+
+# ${PARALLEL_LEVEL} needs to be passed after we run
+# determine_build_parallelism.bash, so it can't be part of ${CMAKE_BUILD_FLAGS}.
+set +e # Don't stop on build failures.
+echo_and_run_timed "Build" cmake --build . ${CMAKE_BUILD_FLAGS} -j ${PARALLEL_LEVEL}
+set -e
 
 ################################################################################
 # TEST - Run Thrust and CUB examples and tests.
 ################################################################################
 
-logger "Test Thrust and CUB..."
-ctest ${CTEST_FLAGS}
+log "Test Thrust and CUB..."
+
+echo_and_run_timed "Test" ctest ${CTEST_FLAGS}
 

--- a/cmake/ThrustBuildCompilerTargets.cmake
+++ b/cmake/ThrustBuildCompilerTargets.cmake
@@ -106,6 +106,12 @@ function(thrust_build_compiler_targets)
     append_option_if_available("-Wno-unneeded-internal-declaration" cxx_compile_options)
   endif()
 
+  if ("Intel" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
+    # Disable warning that inlining is inhibited by compiler thresholds.
+    append_option_if_available("-diag-disable=11074" cxx_compile_options)
+    append_option_if_available("-diag-disable=11076" cxx_compile_options)
+  endif()
+
   if ("NVCXX" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
     # Today:
     # * NVCC accepts CUDA C++ in .cu files but not .cpp files.

--- a/cmake/ThrustCompilerHacks.cmake
+++ b/cmake/ThrustCompilerHacks.cmake
@@ -28,8 +28,25 @@ if ("NVCXX" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -stdpar")
   set(CMAKE_CUDA_HOST_LINK_LAUNCHER "${CMAKE_CUDA_COMPILER}")
   set(CMAKE_CUDA_LINK_EXECUTABLE
-    "<CMAKE_CUDA_HOST_LINK_LAUNCHER> ${CMAKE_CUDA_FLAGS} <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
-endif ()
+    "<CMAKE_CUDA_HOST_LINK_LAUNCHER> <FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+
+  # Setup CMAKE_CXX_LIBRARY_ARCHITECTURE on Debian/Ubuntu so that find_package
+  # works properly.
+  if (EXISTS /etc/debian_version)
+    if (NOT CMAKE_CXX_LIBRARY_ARCHITECTURE)
+      file(GLOB files_in_lib RELATIVE /lib /lib/*-linux-gnu* )
+      foreach (file ${files_in_lib})
+        if ("${file}" MATCHES "${CMAKE_LIBRARY_ARCHITECTURE_REGEX}")
+          set(CMAKE_CXX_LIBRARY_ARCHITECTURE ${file})
+          break()
+        endif()
+      endforeach()
+    endif()
+    if (NOT CMAKE_LIBRARY_ARCHITECTURE)
+      set(CMAKE_LIBRARY_ARCHITECTURE ${CMAKE_CXX_LIBRARY_ARCHITECTURE})
+    endif()
+  endif()
+endif()
 
 # We don't set CMAKE_CUDA_HOST_COMPILER for NVC++; if we do, CMake tries to
 # pass `-ccbin ${CMAKE_CUDA_HOST_COMPILER}` to NVC++, which it doesn't
@@ -90,4 +107,4 @@ if ("NVCXX" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
     ${CMAKE_CUDA17_COMPILE_FEATURES}
     ${CMAKE_CUDA20_COMPILE_FEATURES}
   )
-endif ()
+endif()

--- a/cmake/detect_compute_archs.cu
+++ b/cmake/detect_compute_archs.cu
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2019-2020 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cstdio>
+#include <set>
+#include <string>
+
+int main(int argc, char** argv) {
+  std::set<std::string> archs;
+  int devices;
+  if ((cudaGetDeviceCount(&devices) == cudaSuccess) && (devices > 0)) {
+    for (int dev = 0; dev < devices; ++dev) {
+      char buff[32];
+      cudaDeviceProp prop;
+      if(cudaGetDeviceProperties(&prop, dev) != cudaSuccess) continue;
+      sprintf(buff, "%d%d", prop.major, prop.minor);
+      archs.insert(buff);
+    }
+  }
+  if (archs.empty()) {
+    printf("NONE");
+  } else {
+    bool first = true;
+    for(const auto& arch : archs) {
+      printf(first ? "%s" : ";%s", arch.c_str());
+      first = false;
+    }
+  }
+  printf("\n");
+}

--- a/thrust/cmake/FindTBB.cmake
+++ b/thrust/cmake/FindTBB.cmake
@@ -351,7 +351,6 @@ endforeach ()
 set(TBB_LIBRARY_NAMES tbb)
 get_debug_names(TBB_LIBRARY_NAMES)
 
-
 find_path(TBB_INCLUDE_DIR
           NAMES tbb/tbb.h
           PATHS ${TBB_INC_SEARCH_PATH})
@@ -411,12 +410,18 @@ findpkg_finish(TBB_MALLOC_PROXY tbbmalloc_proxy)
 
 
 #=============================================================================
-#parse all the version numbers from tbb
+# Parse all the version numbers from tbb.
 if(NOT TBB_VERSION)
+  if(EXISTS "${TBB_INCLUDE_DIR}/tbb/version.h")
+    # The newer oneTBB provides tbb/version.h but no tbb/tbb_stddef.h.
+    set(version_file "${TBB_INCLUDE_DIR}/tbb/version.h")
+  else()
+    # Older TBB provides tbb/tbb_stddef.h but no tbb/version.h.
+    set(version_file "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h")
+  endif()
 
- #only read the start of the file
- file(STRINGS
-      "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h"
+  file(STRINGS
+      "${version_file}"
       TBB_VERSION_CONTENTS
       REGEX "VERSION")
 
@@ -437,5 +442,4 @@ if(NOT TBB_VERSION)
         TBB_COMPATIBLE_INTERFACE_VERSION "${TBB_VERSION_CONTENTS}")
 
   set(TBB_VERSION "${TBB_VERSION_MAJOR}.${TBB_VERSION_MINOR}")
-
 endif()


### PR DESCRIPTION
Add gpuCI GPU testing, automatic GPU detection, and support for more compilers:

* CMake: Add support for detecting the compute archs of the GPUs in your system
  at configure time.
* gpuCI: Add a GPU node configuration that builds and tests as little as possible.
* gpuCI: Cleanup logic for different build and test configurations.
* gpuCI: Fix an unfortunate typo in `determine_build_parallelism.bash` which
  led to the parallelism level not being set.
* gpuCI: Add support for NVC++.
* gpuCI: Update to CUDA 11.1 and Ubuntu 20.04.
* gpuCI: Add NVC++ and ICC configurations to the CPU axis file.
* gpuCI: Add a GPU axis file.
* gpuCI: Increase the desired memory per build thread to 4GB.
* gpuCI: Add a -j switch which controls build parallelism to `ci/local/build.bash`.