### PR TITLE
avoids template recursion for and_ / or_

### DIFF
--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -391,6 +391,29 @@ template<typename T1, typename T2>
 
 
 // mpl stuff
+
+#if THRUST_CPP_DIALECT >= 2017
+
+template <typename... Conditions>
+  struct or_
+    : public integral_constant<
+        bool,
+        (... || Conditions::value)
+      >
+{
+}; // end or_
+
+template <typename... Conditions>
+  struct and_
+    : public integral_constant<
+        bool,
+        (... && Conditions::value)
+      >
+{
+}; // end and_
+
+#else
+
 template<typename... Conditions>
   struct or_;
 
@@ -431,6 +454,8 @@ template <typename Condition, typename... Conditions>
         Condition::value && and_<Conditions...>::value>
 {
 }; // end and_
+
+#endif
 
 template <typename Boolean>
   struct not_


### PR DESCRIPTION
Per feedback from @allisonvacanti, although it ended up not being a significant compilation performance hazard, this avoids template recursion in the implementation of `and_` /  `or_`  for the case of `THRUST_CPP_DIALECT >= 2017`