### PR TITLE
Mark CMake var as internal.

### DIFF
--- a/thrust/cmake/thrust-config-version.cmake
+++ b/thrust/cmake/thrust-config-version.cmake
@@ -6,6 +6,7 @@ find_path(_THRUST_VERSION_INCLUDE_DIR thrust/version.h
     ${CMAKE_CURRENT_LIST_DIR}/../..            # Source tree
     ${CMAKE_CURRENT_LIST_DIR}/../../../include # Install tree
 )
+set_property(CACHE _THRUST_VERSION_INCLUDE_DIR PROPERTY TYPE INTERNAL)
 file(READ "${_THRUST_VERSION_INCLUDE_DIR}/thrust/version.h" THRUST_VERSION_HEADER)
 string(REGEX MATCH "#define[ \t]+THRUST_VERSION[ \t]+([0-9]+)" DUMMY "${THRUST_VERSION_HEADER}")
 set(THRUST_VERSION_FLAT ${CMAKE_MATCH_1})


### PR DESCRIPTION
This prevents an internal variable from appearing in CMake's UIs when
our CMake package is used.