### PR TITLE
Fix compilation error when a standard library type is wrapped in `thrust::optional`

### DIFF
--- a/thrust/optional.h
+++ b/thrust/optional.h
@@ -491,7 +491,7 @@ template <class T> struct optional_operations_base : optional_storage_base<T> {
   template <class... Args>
   __host__ __device__
   void construct(Args &&... args) noexcept {
-    new (addressof(this->m_value)) T(std::forward<Args>(args)...);
+    new (thrust::addressof(this->m_value)) T(std::forward<Args>(args)...);
     this->m_has_value = true;
   }
 


### PR DESCRIPTION
Declaring a `thrust::optional<std::string>` causes a following error:
`call of overloaded ‘addressof(std::__cxx11::basic_string<char>&)’ is ambiguous`

This is because both `thrust` and `std` have `addressof` (`std::addressof` is found through ADL).

The patch is to simply explicitly use `thrust::addressof` in this context. Verified locally to fix the issue.