### PR TITLE
Modernize scan_by_key functors / type deductions.

### DIFF
--- a/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/system/cuda/detail/scan_by_key.h
@@ -844,14 +844,14 @@ inclusive_scan_by_key(execution_policy<Derived> &policy,
                       ValOutputIt                value_result,
                       BinaryPred                 binary_pred)
 {
-  typedef typename thrust::iterator_traits<ValOutputIt>::value_type value_type;
+  typedef typename thrust::iterator_traits<ValInputIt>::value_type value_type;
   return cuda_cub::inclusive_scan_by_key(policy,
                                          key_first,
                                          key_last,
                                          value_first,
                                          value_result,
                                          binary_pred,
-                                         plus<value_type>());
+                                         thrust::plus<>());
 }
 
 template <class Derived,
@@ -871,7 +871,7 @@ inclusive_scan_by_key(execution_policy<Derived> &policy,
                                          key_last,
                                          value_first,
                                          value_result,
-                                         equal_to<key_type>());
+                                         thrust::equal_to<>());
 }
 
 
@@ -948,7 +948,7 @@ exclusive_scan_by_key(execution_policy<Derived> &policy,
                                          value_result,
                                          init,
                                          binary_pred,
-                                         plus<Init>());
+                                         plus<>());
 }
 
 template <class Derived,
@@ -971,7 +971,7 @@ exclusive_scan_by_key(execution_policy<Derived> &policy,
                                          value_first,
                                          value_result,
                                          init,
-                                         equal_to<key_type>());
+                                         equal_to<>());
 }
 
 
@@ -986,13 +986,13 @@ exclusive_scan_by_key(execution_policy<Derived> &policy,
                       ValInputIt                 value_first,
                       ValOutputIt                value_result)
 {
-  typedef typename iterator_traits<ValOutputIt>::value_type value_type;
+  typedef typename iterator_traits<ValInputIt>::value_type value_type;
   return cuda_cub::exclusive_scan_by_key(policy,
                                          key_first,
                                          key_last,
                                          value_first,
                                          value_result,
-                                         value_type(0));
+                                         value_type{});
 }
 
 

--- a/thrust/system/detail/generic/scan_by_key.inl
+++ b/thrust/system/detail/generic/scan_by_key.inl
@@ -71,8 +71,7 @@ __host__ __device__
                                        InputIterator2 first2,
                                        OutputIterator result)
 {
-  typedef typename thrust::iterator_traits<InputIterator1>::value_type InputType1;
-  return thrust::inclusive_scan_by_key(exec, first1, last1, first2, result, thrust::equal_to<InputType1>());
+  return thrust::inclusive_scan_by_key(exec, first1, last1, first2, result, thrust::equal_to<>());
 }
 
 
@@ -108,8 +107,8 @@ __host__ __device__
                                        BinaryPredicate binary_pred,
                                        AssociativeOperator binary_op)
 {
-  typedef typename thrust::iterator_traits<OutputIterator>::value_type OutputType;
-  typedef unsigned int HeadFlagType;
+  using OutputType = typename thrust::iterator_traits<InputIterator2>::value_type;
+  using HeadFlagType = unsigned int;
 
   const size_t n = last1 - first1;
 
@@ -146,8 +145,8 @@ __host__ __device__
                                        InputIterator2 first2,
                                        OutputIterator result)
 {
-  typedef typename thrust::iterator_traits<OutputIterator>::value_type OutputType;
-  return thrust::exclusive_scan_by_key(exec, first1, last1, first2, result, OutputType(0));
+  typedef typename thrust::iterator_traits<InputIterator2>::value_type InitType;
+  return thrust::exclusive_scan_by_key(exec, first1, last1, first2, result, InitType{});
 }
 
 
@@ -164,8 +163,7 @@ __host__ __device__
                                        OutputIterator result,
                                        T init)
 {
-  typedef typename thrust::iterator_traits<InputIterator1>::value_type InputType1;
-  return thrust::exclusive_scan_by_key(exec, first1, last1, first2, result, init, thrust::equal_to<InputType1>());
+  return thrust::exclusive_scan_by_key(exec, first1, last1, first2, result, init, thrust::equal_to<>());
 }
 
 
@@ -205,8 +203,8 @@ __host__ __device__
                                        BinaryPredicate binary_pred,
                                        AssociativeOperator binary_op)
 {
-  typedef typename thrust::iterator_traits<OutputIterator>::value_type OutputType;
-  typedef unsigned int HeadFlagType;
+  using OutputType = T;
+  using HeadFlagType = unsigned int;
 
   const size_t n = last1 - first1;
 

--- a/thrust/system/detail/generic/scan_by_key.inl
+++ b/thrust/system/detail/generic/scan_by_key.inl
@@ -16,6 +16,7 @@
 
 
 #include <thrust/detail/config.h>
+#include <thrust/detail/cstdint.h>
 #include <thrust/system/detail/generic/scan_by_key.h>
 #include <thrust/functional.h>
 #include <thrust/transform.h>
@@ -108,7 +109,7 @@ __host__ __device__
                                        AssociativeOperator binary_op)
 {
   using OutputType = typename thrust::iterator_traits<InputIterator2>::value_type;
-  using HeadFlagType = unsigned int;
+  using HeadFlagType = thrust::detail::uint32_t;
 
   const size_t n = last1 - first1;
 
@@ -204,7 +205,7 @@ __host__ __device__
                                        AssociativeOperator binary_op)
 {
   using OutputType = T;
-  using HeadFlagType = unsigned int;
+  using HeadFlagType = thrust::detail::uint32_t;
 
   const size_t n = last1 - first1;
 

--- a/thrust/system/detail/sequential/scan_by_key.h
+++ b/thrust/system/detail/sequential/scan_by_key.h
@@ -52,8 +52,8 @@ __host__ __device__
                                        BinaryPredicate binary_pred,
                                        BinaryFunction binary_op)
 {
-  typedef typename thrust::iterator_traits<InputIterator1>::value_type KeyType;
-  typedef typename thrust::iterator_traits<OutputIterator>::value_type ValueType;
+  using KeyType = typename thrust::iterator_traits<InputIterator1>::value_type;
+  using ValueType = typename thrust::iterator_traits<InputIterator2>::value_type;
 
   // wrap binary_op
   thrust::detail::wrapped_function<
@@ -105,8 +105,8 @@ __host__ __device__
                                        BinaryPredicate binary_pred,
                                        BinaryFunction binary_op)
 {
-  typedef typename thrust::iterator_traits<InputIterator1>::value_type KeyType;
-  typedef typename thrust::iterator_traits<OutputIterator>::value_type ValueType;
+  using KeyType = typename thrust::iterator_traits<InputIterator1>::value_type;
+  using ValueType = T;
 
   if(first1 != last1)
   {


### PR DESCRIPTION
1) Use `InitialValueType` or `InputValueIteratorType` for value
   accumulation, consistent with P0571 and the regular scans.
2) Use transparent thrust::equal_to<> and thrust::plus<> specializations
   instead of the explicitly typed functors.
3) Value-initialize the initial-value type.

This fixes and adds a test for issue NVIDIA/thrust#1374.