### PR TITLE
nvc++ and __CUDACC__

### DIFF
--- a/thrust/detail/complex/c99math.h
+++ b/thrust/detail/complex/c99math.h
@@ -140,7 +140,7 @@ __host__ __device__ inline float copysignf(float x, float y){
 
 
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__NVCOMPILER_CUDA__)
 
 // Simple approximation to log1p as Visual Studio is lacking one
 inline double log1p(double x){

--- a/thrust/detail/config/compiler.h
+++ b/thrust/detail/config/compiler.h
@@ -55,7 +55,7 @@
 #endif // THRUST_HOST_COMPILER
 
 // figure out which device compiler we're using
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__NVCOMPILER_CUDA__)
 #define THRUST_DEVICE_COMPILER THRUST_DEVICE_COMPILER_NVCC
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC
 #define THRUST_DEVICE_COMPILER THRUST_DEVICE_COMPILER_MSVC

--- a/thrust/detail/config/forceinline.h
+++ b/thrust/detail/config/forceinline.h
@@ -22,7 +22,7 @@
 
 #include <thrust/detail/config.h>
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__NVCOMPILER_CUDA__)
 
 #define __thrust_forceinline__ __forceinline__
 

--- a/thrust/system/cuda/config.h
+++ b/thrust/system/cuda/config.h
@@ -28,7 +28,7 @@
 
 #include <thrust/detail/config.h>
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__NVCOMPILER_CUDA__)
 #  if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__>= 350 && defined(__CUDACC_RDC__))
 #    define __THRUST_HAS_CUDART__ 1
 #    define THRUST_RUNTIME_FUNCTION __host__ __device__ __forceinline__


### PR DESCRIPTION
In the near future, `nvc++ -stdpar` will be changed to no longer predefine the macro `__CUDACC__`.  Adjust the uses of `__CUDACC__` in Thrust and CUB to check for NVC++'s stdpar mode in addition to the `__CUDACC__`.