### PR TITLE
nvc++ stdpar OpenMP macro change

### DIFF
--- a/thrust/detail/config/compiler.h
+++ b/thrust/detail/config/compiler.h
@@ -73,7 +73,7 @@
 #endif
 
 // is the device compiler capable of compiling omp?
-#if defined(_OPENMP) || defined(_NV_STDPAR_OPENMP)
+#if defined(_OPENMP) || defined(_NVHPC_STDPAR_OPENMP)
 #define THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE THRUST_TRUE
 #else
 #define THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE THRUST_FALSE


### PR DESCRIPTION
The predefined macro set by `nvc++ -stdpar=multicore` is changing
from `_NV_STDPAR_OPENMP` to `_NVHPC_STDPAR_OPENMP`.  Make the
corresponding change to Thrust.