### PR TITLE
Remove icc from gpuCI.

### DIFF
--- a/ci/axis/cpu.yml
+++ b/ci/axis/cpu.yml
@@ -21,7 +21,6 @@ CXX_TYPE:
   - nvcxx
   - clang
   - gcc
-  - icc
 
 CXX_VER:
   - 5
@@ -31,15 +30,12 @@ CXX_VER:
   - 9
   - 10
   - 20.9
-  - latest
 
 exclude:
   # Excludes by `SDK_TYPE`.
   - CXX_TYPE: gcc
     SDK_TYPE: nvhpc
   - CXX_TYPE: clang
-    SDK_TYPE: nvhpc
-  - CXX_TYPE: icc
     SDK_TYPE: nvhpc
   - CXX_TYPE: nvcxx
     SDK_TYPE: cuda
@@ -61,14 +57,10 @@ exclude:
     CXX_VER: 9
   - CXX_TYPE: nvcxx
     CXX_VER: 10
-  - CXX_TYPE: nvcxx
-    CXX_VER: latest
   - CXX_TYPE: gcc
     CXX_VER: 10
   - CXX_TYPE: gcc
     CXX_VER: 20.9
-  - CXX_TYPE: gcc
-    CXX_VER: latest
   - CXX_TYPE: clang
     CXX_VER: 5
   - CXX_TYPE: clang
@@ -77,20 +69,3 @@ exclude:
     CXX_VER: 10
   - CXX_TYPE: clang
     CXX_VER: 20.9
-  - CXX_TYPE: clang
-    CXX_VER: latest
-  - CXX_TYPE: icc
-    CXX_VER: 5
-  - CXX_TYPE: icc
-    CXX_VER: 6
-  - CXX_TYPE: icc
-    CXX_VER: 7
-  - CXX_TYPE: icc
-    CXX_VER: 8
-  - CXX_TYPE: icc
-    CXX_VER: 9
-  - CXX_TYPE: icc
-    CXX_VER: 10
-  - CXX_TYPE: icc
-    CXX_VER: 20.9
-

--- a/ci/common/build.bash
+++ b/ci/common/build.bash
@@ -80,11 +80,6 @@ if [[ "${CXX_TYPE}" == "nvcxx" ]]; then
   # NVC++ currently uses a lot of memory.
   PARALLEL_LEVEL=1
 else
-  if [[ "${CXX_TYPE}" == "icc" ]]; then
-    # Only the latest version of the Intel C++ compiler, which NVCC doesn't
-    # officially support yet, is freely available.
-    append CMAKE_FLAGS "-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler"
-  fi
   # We're using NVCC so we need to set the host compiler.
   append CMAKE_FLAGS "-DCMAKE_CXX_COMPILER='${CXX}'"
   append CMAKE_FLAGS "-G Ninja"


### PR DESCRIPTION
The prerelease versions of the Intel compilers available freely on ubuntu are too unstable for a CI system.

Disabling the failing CI build until we figure out a long term solution.