### PR TITLE
Add vector_reference and conversion to std::vector

### DIFF
--- a/testing/vector.cu
+++ b/testing/vector.cu
@@ -130,6 +130,35 @@ void TestVectorFromSTLVector(void)
     ASSERT_EQUAL(v[0], 0);
     ASSERT_EQUAL(v[1], 1);
     ASSERT_EQUAL(v[2], 2);
+
+    auto result_stl_vector = std::vector<T>(v);
+
+    ASSERT_EQUAL(result_stl_vector.size(), 3lu);
+    ASSERT_EQUAL(result_stl_vector[0], 0);
+    ASSERT_EQUAL(result_stl_vector[1], 1);
+    ASSERT_EQUAL(result_stl_vector[2], 2);
+
+    thrust::device_vector<T> v2(stl_vector);
+
+    ASSERT_EQUAL(v2.size(), 3lu);
+    ASSERT_EQUAL(v2[0], 0);
+    ASSERT_EQUAL(v2[1], 1);
+    ASSERT_EQUAL(v2[2], 2);
+
+    v2 = stl_vector;
+
+    ASSERT_EQUAL(v2.size(), 3lu);
+    ASSERT_EQUAL(v2[0], 0);
+    ASSERT_EQUAL(v2[1], 1);
+    ASSERT_EQUAL(v2[2], 2);
+
+    auto result_stl_vector2 = std::vector<T>(v);
+
+    ASSERT_EQUAL(result_stl_vector2.size(), 3lu);
+    ASSERT_EQUAL(result_stl_vector2[0], 0);
+    ASSERT_EQUAL(result_stl_vector2[1], 1);
+    ASSERT_EQUAL(result_stl_vector2[2], 2);
+
 }
 DECLARE_VECTOR_UNITTEST(TestVectorFromSTLVector);
 

--- a/testing/vector_reference.cu
+++ b/testing/vector_reference.cu
@@ -107,7 +107,8 @@ DECLARE_VECTOR_UNITTEST(TestVectorReferenceIterators);
 
 __global__ void testVectorRefOnDevice(thrust::vector_reference<int> in, thrust::vector_reference<int> out)
 {
-  if(!in.size() == out.size()) {
+  if(!in.size() == out.size()) 
+  {
     printf("different sizes");
     asm("trap;");
   }
@@ -130,6 +131,13 @@ void TestVectorReferenceOnDevice(void)
   ASSERT_EQUAL(vin[1], vout[1]);
   ASSERT_EQUAL(vin[5], vout[5]);
   ASSERT_EQUAL(vin[8], vout[8]);
+
+  auto stdvec_out = std::vector<int>(vout);
+
+  ASSERT_EQUAL(stdvec[1], stdvec_out[1]);
+  ASSERT_EQUAL(stdvec[5], stdvec_out[5]);
+  ASSERT_EQUAL(stdvec[8], stdvec_out[8]);
+
 }
 DECLARE_UNITTEST(TestVectorReferenceOnDevice);
 

--- a/testing/vector_reference.cu
+++ b/testing/vector_reference.cu
@@ -1,0 +1,158 @@
+#include <unittest/unittest.h>
+
+#include <thrust/vector_reference.h>
+
+void TestVectorReferenceBasic(void)
+{
+  thrust::vector_reference<int> v;
+  ASSERT_EQUAL(v.empty(),true);
+
+  const int arraySize = 7;
+  int data[arraySize] = {10,6,2,50,7,8,5};
+  v = thrust::vector_reference<int>(data, arraySize);
+
+  ASSERT_EQUAL(v.empty(),false);
+  ASSERT_EQUAL(v.size(), 7u);
+
+  ASSERT_EQUAL(v[0], 10);
+  ASSERT_EQUAL(v[3], 50);
+  ASSERT_EQUAL(v[6], 5);
+  ASSERT_EQUAL(v.at(1), 6);
+  ASSERT_EQUAL(v.at(4), 7);
+  ASSERT_EQUAL(v.at(5), 8);
+
+  v[0] = 13;
+  v[3] = 17;
+  v[6] = 42;
+  v.at(1) = 64; 
+  v.at(4) = 845;
+  v.at(5) = 0;
+
+  ASSERT_EQUAL(v.front(), 13);
+  ASSERT_EQUAL(v.back(), 42);
+
+  ASSERT_EQUAL(data[3], 17);
+  ASSERT_EQUAL(data[4], 845);
+  ASSERT_EQUAL(data[5], 0);
+
+  ASSERT_EQUAL(data, v.data());
+
+  thrust::vector_reference<int> v2;
+  swap(v,v2);
+  ASSERT_EQUAL(v.empty(), true);
+  ASSERT_EQUAL(v2.empty(), false);
+  ASSERT_EQUAL(v2[0], 13);
+}
+DECLARE_UNITTEST(TestVectorReferenceBasic);
+
+void TestVectorReferenceOutOfBounds(void)
+{
+  const int arraySize = 7;
+  int data[arraySize] = {10,6,2,50,7,8,5};
+  thrust::vector_reference<int> v(data, arraySize);
+  ASSERT_THROWS(v.at(25)=10, std::out_of_range);
+
+  thrust::vector_reference<int> c(data, arraySize);
+  ASSERT_THROWS(c.at(25), std::out_of_range);
+}
+DECLARE_UNITTEST(TestVectorReferenceOutOfBounds);
+
+
+void TestVectorReferenceSTDvec(void)
+{
+  std::vector<float> vec = {10.0f,6.0f,2.0f,50.0f,7.0f,8.0f,5.0f};
+  
+  auto vref = thrust::make_vector_reference(vec);
+  ASSERT_EQUAL(vec.size(), vref.size());
+  ASSERT_EQUAL(vec[1], vref[1]);
+
+  vref[5] = 0.25f;
+  ASSERT_EQUAL(vec[5], vref[5]);
+}
+DECLARE_UNITTEST(TestVectorReferenceSTDvec);
+
+template <class Vector>
+void TestVectorReferenceFromDifferentVectors(void)
+{
+  std::vector<int> stdvec = {10,6,2,50,7,8,5};
+  
+  Vector vec(stdvec);
+
+  auto vref = thrust::make_vector_reference(vec);
+  ASSERT_EQUAL(vec.size(), vref.size());
+  ASSERT_EQUAL(vec[1], vref[1]);
+
+  vref[5] = 25;
+  ASSERT_EQUAL(vec[5], vref[5]);
+}
+DECLARE_VECTOR_UNITTEST(TestVectorReferenceFromDifferentVectors);
+
+
+template <class Vector>
+void TestVectorReferenceIterators(void)
+{
+  std::vector<int> stdvec = {10,6,2,50,7,8,5};
+  
+  Vector vec(stdvec);
+
+  auto vref = thrust::make_vector_reference(vec);
+  ASSERT_EQUAL(vec.size(), vref.size());
+  ASSERT_EQUAL(vec[1], vref[1]);
+
+  vref[5] = 25;
+  ASSERT_EQUAL(vec[5], vref[5]);
+}
+DECLARE_VECTOR_UNITTEST(TestVectorReferenceIterators);
+
+
+__global__ void testVectorRefOnDevice(thrust::vector_reference<int> in, thrust::vector_reference<int> out)
+{
+  if(!in.size() == out.size()) {
+    printf("different sizes");
+    asm("trap;");
+  }
+
+  for(int i = blockIdx.x*blockDim.x+threadIdx.x; i < in.size(); i += blockDim.x*gridDim.x)
+  {
+    out[i] = in[i];
+  }
+}
+
+void TestVectorReferenceOnDevice(void)
+{
+  std::vector<int> stdvec = {10,6,2,50,7,8,5,12,42,10};
+  thrust::device_vector<int> vin(stdvec);
+  thrust::device_vector<int> vout(vin.size());
+
+  testVectorRefOnDevice<<< 1, 1>>>( thrust::make_device_vector_reference(vin),
+                                     thrust::make_device_vector_reference(vout));
+
+  ASSERT_EQUAL(vin[1], vout[1]);
+  ASSERT_EQUAL(vin[5], vout[5]);
+  ASSERT_EQUAL(vin[8], vout[8]);
+}
+DECLARE_UNITTEST(TestVectorReferenceOnDevice);
+
+void TestVectorReferenceToConst(void)
+{
+  const std::vector<float> cvec = {10.0f,6.0f,2.0f,50.0f,7.0f,8.0f,5.0f};
+  std::vector<float> vec = {10.0f,6.0f,2.0f,50.0f,7.0f,8.0f,5.0f};
+
+  auto vref = thrust::make_vector_reference(cvec);
+  ASSERT_EQUAL(cvec.size(), vref.size());
+  ASSERT_EQUAL(cvec[1], vref[1]);
+  ASSERT_EQUAL(cvec[4], vref[4]);
+  ASSERT_EQUAL(cvec[6], vref[6]);
+  ASSERT_EQUAL(cvec.at(2), vref.at(2));
+  ASSERT_EQUAL(cvec.at(5), vref.at(5));
+
+  thrust::vector_reference<const float> vref2 = thrust::make_vector_reference(vec);
+  ASSERT_EQUAL(vec.size(), vref2.size());
+  ASSERT_EQUAL(vec[1], vref2[1]);
+  ASSERT_EQUAL(vec[4], vref2[4]);
+  ASSERT_EQUAL(vec[6], vref2[6]);
+  ASSERT_EQUAL(vec.at(2), vref2.at(2));
+  ASSERT_EQUAL(vec.at(5), vref2.at(5));
+  
+}
+DECLARE_UNITTEST(TestVectorReferenceToConst);

--- a/thrust/detail/vector_base.h
+++ b/thrust/detail/vector_base.h
@@ -163,6 +163,10 @@ template<typename T, typename Alloc>
     template<typename OtherT, typename OtherAlloc>
     vector_base &operator=(const std::vector<OtherT,OtherAlloc> &v);
 
+    /*! Construct a new std vector and copy the contents of this vector into it.
+     */
+    explicit operator std::vector<T>() const; 
+
     /*! This constructor builds a vector_base from a range.
      *  \param first The beginning of the range.
      *  \param last The end of the range.

--- a/thrust/detail/vector_base.inl
+++ b/thrust/detail/vector_base.inl
@@ -200,6 +200,15 @@ template<typename T, typename Alloc>
 } // end vector_base::operator=()
 
 template<typename T, typename Alloc>
+  vector_base<T,Alloc>
+    ::operator std::vector<T>() const
+{
+  std::vector<T> vec(size());
+  thrust::copy(begin(),end(),vec.begin());
+  return vec;
+}
+
+template<typename T, typename Alloc>
   template<typename IteratorOrIntegralType>
     void vector_base<T,Alloc>
       ::init_dispatch(IteratorOrIntegralType n,

--- a/thrust/vector_reference.h
+++ b/thrust/vector_reference.h
@@ -1,0 +1,244 @@
+/*
+ *  Copyright 2008-2013 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*! \file vector_reference.h
+ *  \brief A reference to memory hold by a vector-lice container. 
+ *         It allows to access the data from C++ and cuda code.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+#include <thrust/swap.h>
+#include <thrust/host_vector.h>
+#include <stdexcept>
+#include <vector>
+
+namespace thrust
+{
+
+/*! A \p device_reference allows access to data in a vector e.g. 
+ * \p device_vector, by holding a non owning pointer as well as the 
+ * size. It implements all data access functions of a vector typically 
+ * has, including iterators. It does not allow access to any of the 
+ * vectors functions that might change the capacity, as it only references 
+ * the internal data. It can be used in hist as well as device code.
+ *
+ *  \see make_vector_reference
+ *  \see make_device_vector_reference
+ */
+template <typename T, typename pointerT = T*, typename refT = T&>
+  class vector_reference
+{
+  public:
+    // typedefs
+    typedef T             value_type;
+    typedef std::size_t   size_type;
+    typedef pointerT      pointer;
+    typedef refT          reference;
+    typedef pointerT      iterator;
+
+    // construction
+
+    /*! Construct an empty \p vector_reference
+     */
+    __host__ __device__
+    vector_reference()
+      : m_data(nullptr), m_size(0) {}
+
+    /*! Construct \p vector_reference that references the data specified by pointer to first element and length.
+     *  \param data pointer to the first element of the array to be referenced
+     *  \param size length of the array to be referenced
+     */
+    __host__ __device__
+    vector_reference(pointer data, size_type size)
+      : m_data(data), m_size(size) {}
+
+    /*!
+     * @brief implicitly convert to a reference to const
+     */
+    template <typename U=T, class = std::enable_if_t< !std::is_const<U>::value> >
+    operator vector_reference<const T>() 
+    {
+      return vector_reference<const T>(m_data,m_size); 
+    }
+
+    // access data
+
+    /*! \brief Read access with to the data contained in the vector, with bounds check.
+     *  \param n The index of the element for which data should be accessed.
+     *  \return Read reference to data.
+     * 
+     * In case of a bounds violation a message is printed using printf (on host as well as device).
+     * If possible, an exception is thrown. If the violation happens inside a CUDA kernel, 
+     * it will be halted and an "unspecified launch error" is raised. 
+     */
+    __host__ __device__
+    reference at(size_type n)
+    {
+      if(n >= m_size) {
+        printf("Tried to access index %lu, but is out of bounds. Size: %lu.", 
+                (unsigned long)(n), (unsigned long)(m_size));
+        #if defined(__CUDA_ARCH__)
+          asm("trap;");
+        #else
+            throw std::out_of_range("vector_reference access out of range!");
+        #endif
+      }
+      return m_data[n];
+    }
+
+    /*! \brief Subscript access to the data contained in this vector_dev.
+     *  \param n The index of the element for which data should be accessed.
+     *  \return Read/write reference to data.
+     *
+     *  This operator allows for easy, array-style, data access.
+     *  Note that data access with this operator is unchecked and
+     *  out_of_range lookups are not defined.
+     */
+    __host__ __device__
+    reference operator[](size_type n) 
+    {return m_data[n];}
+    
+    __host__ __device__
+    reference front() 
+    {return m_data[0];}
+    
+    /*! Access to the last element.
+     *  \return Reference to the last element.
+     */
+    __host__ __device__
+    reference back() 
+    {return m_data[m_size-1];}
+    
+    /*! Allows direct access to internal data.
+     *  \return Pointer to the internal data
+     */
+    __host__ __device__
+    pointer data() { return m_data;} //!< direct data access
+  
+    // iteration
+
+    /*! This method returns an iterator pointing to the beginning
+     *  of this vector_base.
+     *  \return Iterator to the first element of the vector.
+     */
+    __host__ __device__ 
+    iterator begin() { return m_data;} //!< get an iterator to the beginning
+    
+    /*! This method returns an iterator pointing to one element past the last.
+     *  \return begin() + size().
+     */ 
+    __host__ __device__ 
+    iterator end() 
+    { return m_data+size();}
+
+    // check size
+
+    /*! Returns the number of elements in the vector.
+     * \return  the number of elements of stored in the vector
+     */
+    __host__ __device__
+    size_type size() const 
+    {return m_size;}
+    
+    /*! Checks if the vector is empty.
+     *  \return true if the vector has no elements, false otherwise.
+     */
+    __host__ __device__
+    bool empty() const 
+    {return m_size<=0;}
+
+    // other
+
+    /*! This method swaps the contents of this vector_base with another vector_base.
+     *  \param v The vector_base with which to swap.
+     */
+    __host__ __device__
+    void swap(vector_reference &v)
+    { 
+      thrust::swap( this->m_data,v.m_data);
+      thrust::swap( this->m_size,v.m_size);
+    }
+
+  private:
+    pointer m_data;
+    size_type m_size;
+};
+
+/*! Exchanges the values of two vectors_references.
+ *  \p x The first \p vector_reference of interest.
+ *  \p y The second \p vector_reference of interest.
+ */
+template<typename T>
+  void swap(vector_reference<T> &a, vector_reference<T> &b)
+{
+  a.swap(b);
+}
+
+/*!
+ * @brief Creates a vector reference for usage in host code from any type of vector.
+ * 
+ * @tparam T The type of vector to create a reference to.
+ * @param v The vector to create a reference to
+ * @return auto a \p vector_reference, that references v and can be used in host code
+ */
+template <typename T>
+auto make_vector_reference(T& v)
+{
+  return vector_reference<typename T::value_type, typename T::pointer, typename T::reference>(v.data(),v.size());
+}
+
+/*!
+ * @brief Creates a vector reference to const for usage in host code from any type of const vector.
+ * 
+ * @tparam T The type of const vector to create a reference to.
+ * @param v The vector to create a reference to
+ * @return auto a \p vector_reference, that references v and can be used in host code
+ */
+template <typename T>
+auto make_vector_reference(const T& v)
+{
+  return vector_reference<const typename T::value_type, typename T::const_pointer, const typename T::const_reference>(v.data(),v.size());
+}
+
+/*!
+ * @brief Creates a vector reference for usage in device code from vectors that store device data, like \p device_vector.
+ * 
+ * @tparam T The type of vector to create a reference to.
+ * @param v The vector to create a reference to
+ * @return auto a \p vector_reference, that references v and can be used in host code
+ */
+template <typename T>
+auto make_device_vector_reference(T& v)
+{
+  return vector_reference<typename T::value_type>(thrust::raw_pointer_cast(v.data()),v.size());
+}
+
+/*!
+ * @brief Creates a vector reference to const for usage in device code from vectors that store device data, like \p device_vector.
+ * 
+ * @tparam T The type of const vector to create a reference to.
+ * @param v The vector to create a reference to
+ * @return auto a \p vector_reference, that references v and can be used in host code
+ */
+template <typename T>
+auto make_device_vector_reference(const T& v)
+{
+  return vector_reference<const typename T::value_type>(thrust::raw_pointer_cast(v.data()),v.size());
+}
+
+} // namespace thrust


### PR DESCRIPTION
Hi,
I created this pull request to add two features I found helpful when using thrust together with existing cpu code as well as custom CUDA kernels.

## vector_reference
The vector_reference allows access to data in a vector e.g. thrust::device_vector from host and device code. Semantically the name expresses clearly that the data is not owned, but only referenced. It implements all data access functions of a vector typically has, including iterators. It does not allow access to any of the vectors functions that might change the capacity, as it only references the internal data.

## conversion to std::vector
Adds an `explicit operator std::vector<T>()` to the `thrust::vector_base` class. So all of thust's vectors can be easily converted to std::vector, which allows thrust to be integrated seemlessly into existing cpu code.

## examples
This will allow code like the following to be written:
``` c++
__global__ void kernel(thrust::vector_reference<const int> in, thrust::vector_reference<int> out) {
  if(!in.size() == out.size())  {
    printf("different sizes");
    asm("trap;");
  }

  for(int i = blockIdx.x*blockDim.x+threadIdx.x; i < in.size(); i += blockDim.x*gridDim.x) {
    out[i] = in[i];
  }
}

std::vector<int> func(const std:.vector<int>& input) {
  thrust::device_vector<int> vin(input);
  thrust::device_vector<int> vout(vin.size());
  kernel<<< 128, 128>>>( thrust::make_device_vector_reference(vin),
                                          thrust::make_device_vector_reference(vout));
  return std::vector<int>(vout);
}
```
The vector_reference is also useful for functions that need to be called from host as well as device code. 

Let me know if you have any feedback. I hope that others will find it useful as well.
