### PR TITLE
Fix transform_iterator with non-copyable types

### DIFF
--- a/testing/transform_iterator.cu
+++ b/testing/transform_iterator.cu
@@ -7,6 +7,8 @@
 #include <thrust/sequence.h>
 #include <thrust/iterator/counting_iterator.h>
 
+#include <memory>
+
 template <class Vector>
 void TestTransformIterator(void)
 {
@@ -83,4 +85,29 @@ struct TestTransformIteratorReduce
     }
 };
 VariableUnitTest<TestTransformIteratorReduce, IntegralTypes> TestTransformIteratorReduceInstance;
+
+
+struct ExtractValue{
+    int operator()(std::unique_ptr<int> const& n){
+        return *n;
+    }
+};
+
+void TestTransformIteratorNonCopyable(){
+
+    thrust::host_vector<std::unique_ptr<int>> hv(4);
+    hv[0].reset(new int{1});
+    hv[1].reset(new int{2});
+    hv[2].reset(new int{3});
+    hv[3].reset(new int{4});
+
+    auto transformed = thrust::make_transform_iterator(hv.begin(), ExtractValue{});
+    ASSERT_EQUAL(transformed[0], 1);
+    ASSERT_EQUAL(transformed[1], 2);
+    ASSERT_EQUAL(transformed[2], 3);
+    ASSERT_EQUAL(transformed[3], 4);
+
+}
+
+DECLARE_UNITTEST(TestTransformIteratorNonCopyable);
 

--- a/thrust/iterator/transform_iterator.h
+++ b/thrust/iterator/transform_iterator.h
@@ -312,7 +312,7 @@ template <class AdaptableUnaryFunction, class Iterator, class Reference = use_de
       // Create a temporary to allow iterators with wrapped references to
       // convert to their value type before calling m_f. Note that this
       // disallows non-constant operations through m_f.
-      typename thrust::iterator_value<Iterator>::type x = *this->base();
+      typename thrust::iterator_value<Iterator>::type const& x = *this->base();
       return m_f(x);
     }
 


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/thrust/issues/1421

Previously, the transform_iterator implementation would make a copy
of the adapted iterators value when dereferencing it in order to
force conversion to the value_type. This prevented transform_iterators
over non-copyable types. Using a reference instead allows for forcing
the conversion without invoking a copy ctor.