### PR TITLE
fix > intmax num inputs for scan_by_key

### DIFF
--- a/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/system/cuda/detail/scan_by_key.h
@@ -512,8 +512,8 @@ namespace __scan_by_key {
             inequality_op(equality_op_),
             scan_op(scan_op_)
       {
-        Size tile_idx      = blockIdx.x;
-        Size tile_base     = ITEMS_PER_TILE * tile_idx;
+        int  tile_idx      = blockIdx.x;
+        Size tile_base     = ITEMS_PER_TILE * static_cast<Size>(tile_idx);
         Size num_remaining = num_items - tile_base;
 
         if (num_remaining > ITEMS_PER_TILE)

--- a/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/system/cuda/detail/scan_by_key.h
@@ -512,7 +512,7 @@ namespace __scan_by_key {
             inequality_op(equality_op_),
             scan_op(scan_op_)
       {
-        int  tile_idx      = blockIdx.x;
+        Size tile_idx      = blockIdx.x;
         Size tile_base     = ITEMS_PER_TILE * tile_idx;
         Size num_remaining = num_items - tile_base;
 
@@ -734,7 +734,7 @@ namespace __scan_by_key {
                              ScanOp                     scan_op,
                              AddInitToScan              add_init_to_scan)
   {
-    int          num_items    = static_cast<int>(thrust::distance(keys_first, keys_last));
+    Size         num_items    = static_cast<Size>(thrust::distance(keys_first, keys_last));
     size_t       storage_size = 0;
     cudaStream_t stream       = cuda_cub::stream(policy);
     bool         debug_sync   = THRUST_DEBUG_SYNC_FLAG;

--- a/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/system/cuda/detail/scan_by_key.h
@@ -734,7 +734,7 @@ namespace __scan_by_key {
                              ScanOp                     scan_op,
                              AddInitToScan              add_init_to_scan)
   {
-    Size         num_items    = static_cast<Size>(thrust::distance(keys_first, keys_last));
+    size_t       num_items    = static_cast<size_t>(thrust::distance(keys_first, keys_last));
     size_t       storage_size = 0;
     cudaStream_t stream       = cuda_cub::stream(policy);
     bool         debug_sync   = THRUST_DEBUG_SYNC_FLAG;


### PR DESCRIPTION
Fixes #1410. With these updates `scan_by_key` supports a higher number of inputs. The number of inputs is now capped by `tile_idx`, which is type `int`. The actual number of supported inputs is `intmax * ITEMS_PER_TILE`, where `ITEMS_PER_TILE` is determined via cub/thrust PtxPolicy.