### PR TITLE
Update deprecation mechanism.

### DIFF
--- a/cmake/ThrustBuildTargetList.cmake
+++ b/cmake/ThrustBuildTargetList.cmake
@@ -314,6 +314,10 @@ function(thrust_build_target_list)
   add_flag_option(IGNORE_DEPRECATED_COMPILER "Don't warn about deprecated compilers." OFF)
   add_flag_option(IGNORE_CUB_VERSION_CHECK "Don't warn about mismatched CUB versions." OFF)
 
+  # By default, suppress deprecation warnings when building our test suite,
+  ## since we'll need to test deprecated APIs with `-Werror`.
+  add_flag_option(IGNORE_DEPRECATED_API "Don't warn about deprecated Thrust or CUB APIs." ON)
+
   # Top level meta-target. Makes it easier to just build thrust targets when
   # building both CUB and Thrust. Add all project files here so IDEs will be
   # aware of them. This will not generate build rules.

--- a/internal/build/common_build.mk
+++ b/internal/build/common_build.mk
@@ -6,6 +6,10 @@ ifeq ($(OS),Linux)
   LIBRARIES += m
 endif
 
+# Disable our THRUST_DEPRECATED and CUB_DEPRECATED macros for internal
+# builds, since we need to build and test our deprecated APIs with -Werror.
+CUDACC_FLAGS += -DTHRUST_IGNORE_DEPRECATED_API
+
 include $(ROOTDIR)/thrust/internal/build/common_compiler.mk
 
 # Add /bigobj to Windows build flag to workaround building Thrust with debug

--- a/thrust/cmake/thrust-config.cmake
+++ b/thrust/cmake/thrust-config.cmake
@@ -50,6 +50,7 @@
 #
 # # Create target with HOST=CPP DEVICE=CUDA and some advanced flags set
 # thrust_create_target(TargetName
+#   IGNORE_DEPRECATED_API         # Silence build warnings about deprecated APIs
 #   IGNORE_DEPRECATED_CPP_DIALECT # Silence build warnings about deprecated compilers and C++ standards
 #   IGNORE_DEPRECATED_CPP_11      # Only silence deprecation warnings for C++11
 #   IGNORE_DEPRECATED_COMPILER    # Only silence deprecation warnings for old compilers
@@ -104,6 +105,7 @@ function(thrust_create_target target_name)
     ADVANCED
     FROM_OPTIONS
     IGNORE_CUB_VERSION_CHECK
+    IGNORE_DEPRECATED_API
     IGNORE_DEPRECATED_COMPILER
     IGNORE_DEPRECATED_CPP_11
     IGNORE_DEPRECATED_CPP_DIALECT
@@ -194,6 +196,10 @@ function(thrust_create_target target_name)
 
   if (TCT_IGNORE_DEPRECATED_CPP_DIALECT)
     target_compile_definitions(${target_name} INTERFACE "THRUST_IGNORE_DEPRECATED_CPP_DIALECT")
+  endif()
+
+  if (TCT_IGNORE_DEPRECATED_API)
+    target_compile_definitions(${target_name} INTERFACE "THRUST_IGNORE_DEPRECATED_API")
   endif()
 
   if (TCT_IGNORE_DEPRECATED_CPP_11)

--- a/thrust/detail/config/deprecated.h
+++ b/thrust/detail/config/deprecated.h
@@ -21,8 +21,17 @@
 #pragma once
 
 #include <thrust/detail/config/compiler.h>
+#include <thrust/detail/config/cpp_dialect.h>
 
-#if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC
+#if defined(CUB_IGNORE_DEPRECATED_API) && !defined(THRUST_IGNORE_DEPRECATED_API)
+#  define THRUST_IGNORE_DEPRECATED_API
+#endif
+
+#ifdef THRUST_IGNORE_DEPRECATED_API
+#  define THRUST_DEPRECATED
+#elif THRUST_CPP_DIALECT >= 2014
+#  define THRUST_DEPRECATED [[deprecated]]
+#elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC
 #  define THRUST_DEPRECATED __declspec(deprecated)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
 #  define THRUST_DEPRECATED __attribute__((deprecated))

--- a/thrust/iterator/detail/device_system_tag.h
+++ b/thrust/iterator/detail/device_system_tag.h
@@ -29,12 +29,3 @@ namespace thrust
 typedef thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::tag device_system_tag;
 
 } // end thrust
-
-// TODO remove this in 1.8.0
-namespace thrust
-{
-
-typedef THRUST_DEPRECATED device_system_tag device_space_tag;
-
-} // end thrust
-

--- a/thrust/iterator/detail/host_system_tag.h
+++ b/thrust/iterator/detail/host_system_tag.h
@@ -29,12 +29,3 @@ namespace thrust
 typedef thrust::system::__THRUST_HOST_SYSTEM_NAMESPACE::tag host_system_tag;
 
 } // end thrust
-
-// TODO remove this in 1.8.0
-namespace thrust
-{
-
-typedef THRUST_DEPRECATED host_system_tag host_space_tag;
-
-} // end thrust
-


### PR DESCRIPTION
Updated the deprecation mechanism to provide an opt-out, cmake options, and C++14 syntax. Our internal build will opt-out of deprecation warnings so we can continue to maintain and test deprecated APIs. This corresponds with the changes in NVIDIA/cub#320.