### PR TITLE
Reduce scan_by_key memory consumption

### DIFF
--- a/thrust/system/detail/generic/scan_by_key.inl
+++ b/thrust/system/detail/generic/scan_by_key.inl
@@ -109,7 +109,7 @@ __host__ __device__
                                        AssociativeOperator binary_op)
 {
   using OutputType = typename thrust::iterator_traits<InputIterator2>::value_type;
-  using HeadFlagType = thrust::detail::uint32_t;
+  using HeadFlagType = thrust::detail::uint8_t;
 
   const size_t n = last1 - first1;
 
@@ -205,7 +205,7 @@ __host__ __device__
                                        AssociativeOperator binary_op)
 {
   using OutputType = T;
-  using HeadFlagType = thrust::detail::uint32_t;
+  using HeadFlagType = thrust::detail::uint8_t;
 
   const size_t n = last1 - first1;
 


### PR DESCRIPTION
Reduce scan_by_key memory consumption by using uint8_t rather than uint32_t on HeadFlagType