### PR TITLE
Fixed call of max() on MSVC compiler

### DIFF
--- a/thrust/mr/allocator.h
+++ b/thrust/mr/allocator.h
@@ -98,7 +98,7 @@ public:
     __host__ __device__
     size_type max_size() const
     {
-        return std::numeric_limits<size_type>::max() / sizeof(T);
+        return (std::numeric_limits<size_type>::max)() / sizeof(T);
     }
 
     /*! Constructor.


### PR DESCRIPTION
Fixed call of max() on MSVC compiler