### PR TITLE
Fix default constructor of counting iterator

### DIFF
--- a/testing/counting_iterator.cu
+++ b/testing/counting_iterator.cu
@@ -8,6 +8,14 @@
 
 THRUST_DISABLE_MSVC_POSSIBLE_LOSS_OF_DATA_WARNING_BEGIN
 
+template <typename T>
+void TestCountingDefaultConstructor(void)
+{
+  thrust::counting_iterator<T> iter0;
+  ASSERT_EQUAL(*iter0, T{});
+}
+DECLARE_GENERIC_UNITTEST(TestCountingDefaultConstructor);
+
 void TestCountingIteratorCopyConstructor(void)
 {
     thrust::counting_iterator<int> iter0(100);

--- a/thrust/iterator/counting_iterator.h
+++ b/thrust/iterator/counting_iterator.h
@@ -144,11 +144,11 @@ template<typename Incrementable,
     /*! \endcond
      */
 
-    /*! Null constructor initializes this \p counting_iterator's \c Incrementable
-     *  counter using its null constructor.
+    /*! Default constructor initializes this \p counting_iterator's counter to
+     * `Incrementable{}`.
      */
     __host__ __device__
-    counting_iterator() {}
+    counting_iterator() : super_t(Incrementable{}) {}
 
     /*! Copy constructor copies the value of another \p counting_iterator into a
      *  new \p counting_iterator.


### PR DESCRIPTION
This PR contains a fix for [the issue](https://github.com/NVIDIA/thrust/issues/1470) related to uninitialized fields in the counting iterator.