### PR TITLE
Fix std::allocator traits

### DIFF
--- a/thrust/detail/allocator/allocator_traits.h
+++ b/thrust/detail/allocator/allocator_traits.h
@@ -26,6 +26,8 @@
 #include <thrust/detail/type_traits/has_member_function.h>
 #include <thrust/detail/type_traits.h>
 
+#include <memory>
+
 THRUST_NAMESPACE_BEGIN
 namespace detail
 {
@@ -69,6 +71,25 @@ template<typename Alloc, typename U>
 
   typedef thrust::detail::integral_constant<bool, value> type;
 };
+
+// The following fields of std::allocator have been deprecated (since C++17).
+// There's no way to detect it other than explicit specialization.
+#if THRUST_CPP_DIALECT >= 2017
+#define THRUST_SPECIALIZE_DEPRECATED(trait_name)                               \
+template <typename T>                                                          \
+struct trait_name<std::allocator<T>> : false_type {};
+
+THRUST_SPECIALIZE_DEPRECATED(has_is_always_equal)
+THRUST_SPECIALIZE_DEPRECATED(has_pointer)
+THRUST_SPECIALIZE_DEPRECATED(has_const_pointer)
+THRUST_SPECIALIZE_DEPRECATED(has_reference)
+THRUST_SPECIALIZE_DEPRECATED(has_const_reference)
+
+#undef THRUST_SPECIALIZE_DEPRECATED
+
+template<typename T, typename U>
+struct has_rebind<std::allocator<T>, U> : false_type {};
+#endif
 
 template<typename T>
   struct nested_pointer


### PR DESCRIPTION
This PR fixes [the following issue](https://github.com/NVIDIA/thrust/issues/1214). 

SFINAE doesn't allow us to specialize code depending on the deprecation attribute. Therefore existing `allocator_traits` led to deprecated fields accesses. In this PR I explicitly specialized `__THRUST_DEFINE_HAS_NESTED_TYPE` for `std::allocator` in case of C++ >= 17. 