### PR TITLE
First checkpoint for Wconversion warning fixes

### DIFF
--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -650,7 +650,7 @@ template<typename T1, typename T2>
 
   template<typename T> static typename add_reference<T>::type declval();
   
-  template<unsigned int> struct helper { typedef void * type; };
+  template<size_t> struct helper { typedef void * type; };
 
   template<typename U1, typename U2> static yes_type test(typename helper<sizeof(declval<U1>() = declval<U2>())>::type);
 

--- a/thrust/system/cuda/detail/adjacent_difference.h
+++ b/thrust/system/cuda/detail/adjacent_difference.h
@@ -108,7 +108,7 @@ namespace __adjacent_difference {
   {
     enum
     {
-      INPUT_SIZE                  = sizeof(T),
+      INPUT_SIZE                  = static_cast<int>(sizeof(T)),
       NOMINAL_4B_ITEMS_PER_THREAD = 7,
       ITEMS_PER_THREAD            = items_per_thread<INPUT_SIZE,
                                           NOMINAL_4B_ITEMS_PER_THREAD>::value

--- a/thrust/system/cuda/detail/merge.h
+++ b/thrust/system/cuda/detail/merge.h
@@ -189,7 +189,7 @@ namespace __merge {
 
   namespace mpl = thrust::detail::mpl::math;
 
-  template<size_t NOMINAL_4B_ITEMS_PER_THREAD, size_t INPUT_SIZE>
+  template<int NOMINAL_4B_ITEMS_PER_THREAD, size_t INPUT_SIZE>
   struct items_per_thread
   {
     enum
@@ -201,8 +201,8 @@ namespace __merge {
               mpl::max<
                   int,
                   1,
-                  (NOMINAL_4B_ITEMS_PER_THREAD * 4 / INPUT_SIZE)>::value>::value,
-      value = mpl::is_odd<size_t, ITEMS_PER_THREAD>::value
+                  static_cast<int>(NOMINAL_4B_ITEMS_PER_THREAD * 4 / INPUT_SIZE)>::value>::value,
+      value = mpl::is_odd<int, ITEMS_PER_THREAD>::value
                   ? ITEMS_PER_THREAD
                   : ITEMS_PER_THREAD + 1
     };

--- a/thrust/system/cuda/detail/reduce_by_key.h
+++ b/thrust/system/cuda/detail/reduce_by_key.h
@@ -115,9 +115,9 @@ namespace __reduce_by_key {
           mpl::max<
               int,
               1,
-              ((NOMINAL_4B_ITEMS_PER_THREAD * 8) +
+              static_cast<int>(((NOMINAL_4B_ITEMS_PER_THREAD * 8) +
                COMBINED_INPUT_BYTES - 1) /
-                  COMBINED_INPUT_BYTES>::value>::value,
+                  COMBINED_INPUT_BYTES)>::value>::value,
     };
 
     typedef PtxPolicy<128,

--- a/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/system/cuda/detail/scan_by_key.h
@@ -89,8 +89,8 @@ namespace __scan_by_key {
               int,
               1,
               ((NOMINAL_4B_ITEMS_PER_THREAD * 8) +
-               COMBINED_INPUT_BYTES - 1) /
-                  COMBINED_INPUT_BYTES>::value>::value,
+               static_cast<int>(COMBINED_INPUT_BYTES) - 1) /
+                  static_cast<int>(COMBINED_INPUT_BYTES)>::value>::value,
     };
 
     typedef PtxPolicy<128,

--- a/thrust/system/cuda/detail/set_operations.h
+++ b/thrust/system/cuda/detail/set_operations.h
@@ -239,9 +239,9 @@ namespace __set_operations {
           mpl::max<
               int,
               1,
-              ((NOMINAL_4B_ITEMS_PER_THREAD * 4) +
+              static_cast<int>(((NOMINAL_4B_ITEMS_PER_THREAD * 4) +
                COMBINED_INPUT_BYTES - 1) /
-                  COMBINED_INPUT_BYTES>::value>::value,
+                  COMBINED_INPUT_BYTES)>::value>::value,
     };
 
     typedef PtxPolicy<128,
@@ -266,9 +266,9 @@ namespace __set_operations {
           mpl::max<
               int,
               1,
-              ((NOMINAL_4B_ITEMS_PER_THREAD * 4) +
+              static_cast<int>(((NOMINAL_4B_ITEMS_PER_THREAD * 4) +
                COMBINED_INPUT_BYTES - 1) /
-                  COMBINED_INPUT_BYTES>::value>::value,
+                  COMBINED_INPUT_BYTES)>::value>::value,
     };
 
     typedef PtxPolicy<256,
@@ -293,9 +293,9 @@ namespace __set_operations {
           mpl::max<
               int,
               1,
-              ((NOMINAL_4B_ITEMS_PER_THREAD * 4) +
+              static_cast<int>(((NOMINAL_4B_ITEMS_PER_THREAD * 4) +
                COMBINED_INPUT_BYTES - 1) /
-                  COMBINED_INPUT_BYTES>::value>::value,
+                  COMBINED_INPUT_BYTES)>::value>::value,
     };
 
     typedef PtxPolicy<512,

--- a/thrust/system/cuda/detail/unique.h
+++ b/thrust/system/cuda/detail/unique.h
@@ -99,7 +99,7 @@ namespace __unique {
 
   namespace mpl = thrust::detail::mpl::math;
 
-  template<class T, size_t NOMINAL_4B_ITEMS_PER_THREAD>
+  template<class T, int NOMINAL_4B_ITEMS_PER_THREAD>
   struct items_per_thread
   {
     enum
@@ -109,7 +109,7 @@ namespace __unique {
           NOMINAL_4B_ITEMS_PER_THREAD,
           mpl::max<int,
                    1,
-                   (NOMINAL_4B_ITEMS_PER_THREAD * 4 /
+                   static_cast<int>(NOMINAL_4B_ITEMS_PER_THREAD * 4 /
                     sizeof(T))>::value>::value
     };
   };

--- a/thrust/system/cuda/detail/unique_by_key.h
+++ b/thrust/system/cuda/detail/unique_by_key.h
@@ -110,11 +110,11 @@ namespace __unique_by_key {
     {
       value = mpl::min<
           int,
-          NOMINAL_4B_ITEMS_PER_THREAD,
+          static_cast<int>(NOMINAL_4B_ITEMS_PER_THREAD),
           mpl::max<int,
                    1,
-                   (NOMINAL_4B_ITEMS_PER_THREAD * 4 /
-                    sizeof(T))>::value>::value
+                   static_cast<int>(NOMINAL_4B_ITEMS_PER_THREAD * 4 /
+                   sizeof(T))>::value>::value
     };
   };
 

--- a/thrust/system/detail/sequential/stable_radix_sort.inl
+++ b/thrust/system/detail/sequential/stable_radix_sort.inl
@@ -51,7 +51,7 @@ struct RadixEncoder<char> : public thrust::unary_function<char, unsigned char>
   {
     if(std::numeric_limits<char>::is_signed)
     {
-      return x ^ static_cast<unsigned char>(1) << (8 * sizeof(unsigned char) - 1);
+      return static_cast<unsigned char>(x) ^ static_cast<unsigned char>(1) << (8 * sizeof(unsigned char) - 1);
     }
     else
     {
@@ -66,7 +66,7 @@ struct RadixEncoder<signed char> : public thrust::unary_function<signed char, un
   __host__ __device__
   unsigned char operator()(signed char x) const
   {
-    return x ^ static_cast<unsigned char>(1) << (8 * sizeof(unsigned char) - 1);
+    return static_cast<unsigned char>(x) ^ static_cast<unsigned char>(1) << (8 * sizeof(unsigned char) - 1);
   }
 };
 
@@ -76,7 +76,7 @@ struct RadixEncoder<short> : public thrust::unary_function<short, unsigned short
   __host__ __device__
   unsigned short operator()(short x) const
   {
-    return x ^ static_cast<unsigned short>(1) << (8 * sizeof(unsigned short) - 1);
+    return static_cast<unsigned short>(x) ^ static_cast<unsigned short>(1) << (8 * sizeof(unsigned short) - 1);
   }
 };
 


### PR DESCRIPTION
Referencing NVIDIA/thrust#1478 and also hand-in-hand with NVIDIA/cub branch bug/github/wconversion-thrust1478

This is to check the style is right and I am following best practices before adding -Wconversions to the gcc build and tackling those warnings. With this branch and the cub branch bug/github/wconversion-thrust1478, the simple reproducer should described in the orignal issue #1478 can build nvcc main.cu -Xcompiler=-Wconversion without warning.