### PR TITLE
Build bench.cu from CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,13 @@ cmake_minimum_required(VERSION 3.17)
 option(THRUST_ENABLE_HEADER_TESTING "Test that all public headers compile." "ON")
 option(THRUST_ENABLE_TESTING "Build Thrust testing suite." "ON")
 option(THRUST_ENABLE_EXAMPLES "Build Thrust examples." "ON")
+option(THRUST_ENABLE_BENCHMARKS "Build Thrust runtime benchmarks." "OFF")
 option(THRUST_INCLUDE_CUB_CMAKE "Build CUB tests and examples. (Requires CUDA)." "OFF")
+
+# Mark this option as advanced for now. We'll revisit this later once the new
+# benchmarks are ready. For now, we just need to expose a way to compile
+# bench.cu from CMake for NVIDIA's internal builds.
+mark_as_advanced(THRUST_ENABLE_BENCHMARKS)
 
 # Check if we're actually building anything before continuing. If not, no need
 # to search for deps, etc. This is a common approach for packagers that just
@@ -57,6 +63,7 @@ option(THRUST_INCLUDE_CUB_CMAKE "Build CUB tests and examples. (Requires CUDA)."
 if (NOT (THRUST_ENABLE_HEADER_TESTING OR
          THRUST_ENABLE_TESTING OR
          THRUST_ENABLE_EXAMPLES OR
+         THRUST_ENABLE_BENCHMARKS OR
          THRUST_INCLUDE_CUB_CMAKE))
   return()
 endif()
@@ -116,6 +123,10 @@ endif()
 
 if (THRUST_ENABLE_EXAMPLES)
   add_subdirectory(examples)
+endif()
+
+if (THRUST_ENABLE_BENCHMARKS)
+  add_subdirectory(internal/benchmark)
 endif()
 
 if (THRUST_INCLUDE_CUB_CMAKE AND THRUST_CUDA_FOUND)

--- a/ci/common/build.bash
+++ b/ci/common/build.bash
@@ -148,6 +148,9 @@ case "${COVERAGE_PLAN}" in
     append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_WORKLOAD=LARGE"
     ;;
   Thorough)
+    # Build the legacy bench.cu. We'll probably want to remove this when we
+    # switch to the new, heavier thrust_benchmarks project.
+    append CMAKE_FLAGS "-DTHRUST_ENABLE_BENCHMARKS=ON"
     append CMAKE_FLAGS "-DTHRUST_ENABLE_MULTICONFIG=ON"
     append CMAKE_FLAGS "-DTHRUST_IGNORE_DEPRECATED_CPP_11=ON"
     append CMAKE_FLAGS "-DTHRUST_MULTICONFIG_ENABLE_DIALECT_ALL=ON"

--- a/internal/benchmark/CMakeLists.txt
+++ b/internal/benchmark/CMakeLists.txt
@@ -1,0 +1,29 @@
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  # MSVC builds fail at runtime. Benchmarks are linux-only for now.
+  message(STATUS "Thrust benchmarking is not available on MSVC.")
+  return()
+endif()
+
+add_custom_target(thrust.all.bench)
+
+foreach(thrust_target IN LISTS THRUST_TARGETS)
+  thrust_get_target_property(config_host ${thrust_target} HOST)
+  thrust_get_target_property(config_device ${thrust_target} DEVICE)
+  thrust_get_target_property(config_prefix ${thrust_target} PREFIX)
+
+  # Skip non cpp.cuda targets:
+  if (NOT config_host   STREQUAL "CPP" OR
+      NOT config_device STREQUAL "CUDA")
+    continue()
+  endif()
+
+  set(bench_target ${config_prefix}.bench)
+
+  add_executable(${bench_target} bench.cu)
+  target_link_libraries(${bench_target} PRIVATE ${thrust_target})
+  target_include_directories(${bench_target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+  thrust_clone_target_properties(${bench_target} ${thrust_target})
+
+  add_dependencies(thrust.all.bench ${bench_target})
+  add_dependencies(${config_prefix}.all ${bench_target})
+endforeach()


### PR DESCRIPTION
Builds the older benchmarking executable on non-MSVC platforms when CMake option `THRUST_ENABLE_BENCHMARKS` is enabled. This will be replaced by [thrust_benchmarks](https://github.com/allisonvacanti/thrust_benchmark) before much longer, but we need this to build from CMake in the meantime for Reasons:tm:.

This adds compilation logic only -- It is not executed by `ctest`.

Enabled this for gpuCI/cpu builders, since it compiles fairly quickly.