### PR TITLE
Add THRUST_PRAGMA_OMP.

### DIFF
--- a/testing/sequence.cu
+++ b/testing/sequence.cu
@@ -139,10 +139,21 @@ struct Vector
 };
 
 // Vector-Vector addition
-__host__ __device__ Vector operator+(const Vector a, const Vector b) { return Vector{a.x + b.x, a.y + b.y}; }
+__host__ __device__ Vector operator+(const Vector a, const Vector b)
+{
+  return Vector{a.x + b.x, a.y + b.y};
+}
+
 // Vector-Scalar Multiplication
-__host__ __device__ Vector operator*(const int a, const Vector b) { return Vector{a * b.x, a * b.y}; }
-__host__ __device__ Vector operator*(const Vector b, const int a) { return Vector{a * b.x, a * b.y}; }
+// Multiplication by std::size_t is required by thrust::sequence.
+__host__ __device__ Vector operator*(const std::size_t a, const Vector b)
+{
+  return Vector{static_cast<int>(a) * b.x, static_cast<int>(a) * b.y};
+}
+__host__ __device__ Vector operator*(const Vector b, const std::size_t a)
+{
+  return Vector{static_cast<int>(a) * b.x, static_cast<int>(a) * b.y};
+}
 
 void TestSequenceNoSizeTConversion()
 {

--- a/thrust/system/omp/detail/for_each.inl
+++ b/thrust/system/omp/detail/for_each.inl
@@ -20,12 +20,12 @@
  */
 
 #include <thrust/detail/config.h>
+#include <thrust/detail/function.h>
 #include <thrust/detail/static_assert.h>
 #include <thrust/distance.h>
-#include <thrust/detail/function.h>
-#include <thrust/iterator/iterator_traits.h>
-#include <thrust/distance.h>
 #include <thrust/for_each.h>
+#include <thrust/iterator/iterator_traits.h>
+#include <thrust/system/omp/detail/pragma_omp.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system
@@ -61,14 +61,11 @@ RandomAccessIterator for_each_n(execution_policy<DerivedPolicy> &,
   // create a wrapped function for f
   thrust::detail::wrapped_function<UnaryFunction,void> wrapped_f(f);
 
-// do not attempt to compile the body of this function, which depends on #pragma omp,
-// without support from the compiler
-// XXX implement the body of this function in another file to eliminate this ugliness
-#if (THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE == THRUST_TRUE)
   // use a signed type for the iteration variable or suffer the consequences of warnings
   typedef typename thrust::iterator_difference<RandomAccessIterator>::type DifferenceType;
   DifferenceType signed_n = n;
-#pragma omp parallel for
+
+  THRUST_PRAGMA_OMP(parallel for)
   for(DifferenceType i = 0;
       i < signed_n;
       ++i)
@@ -76,7 +73,6 @@ RandomAccessIterator for_each_n(execution_policy<DerivedPolicy> &,
     RandomAccessIterator temp = first + i;
     wrapped_f(*temp);
   }
-#endif // THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE
 
   return first + n;
 } // end for_each_n() 

--- a/thrust/system/omp/detail/pragma_omp.h
+++ b/thrust/system/omp/detail/pragma_omp.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+* Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of the NVIDIA CORPORATION nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC
+// MSVC ICEs when using the standard C++11 `_Pragma` operator with OpenMP
+// directives.
+// WAR this by using the MSVC-extension `__pragma`. See this link for more info:
+// https://developercommunity.visualstudio.com/t/Using-C11s-_Pragma-with-OpenMP-dire/1590628
+#define THRUST_PRAGMA_OMP_IMPL(directive) __pragma(directive)
+#else // Not MSVC:
+#define THRUST_PRAGMA_OMP_IMPL(directive) _Pragma(#directive)
+#endif
+
+// For internal use only -- THRUST_PRAGMA_OMP is used to switch between
+// different flavors of openmp pragmas. Pragmas are not emitted when OpenMP is
+// not available.
+//
+// Usage:
+//   Replace: #pragma omp parallel for
+//   With   : THRUST_PRAGMA_OMP(parallel for)
+//
+#if defined(_NVHPC_STDPAR_OPENMP) && _NVHPC_STDPAR_OPENMP == 1
+#define THRUST_PRAGMA_OMP(directive) THRUST_PRAGMA_OMP_IMPL(omp_stdpar directive)
+#elif defined(_OPENMP)
+#define THRUST_PRAGMA_OMP(directive) THRUST_PRAGMA_OMP_IMPL(omp directive)
+#else
+#define THRUST_PRAGMA_OMP(directive)
+#endif

--- a/thrust/system/omp/detail/reduce_intervals.inl
+++ b/thrust/system/omp/detail/reduce_intervals.inl
@@ -62,9 +62,7 @@ void reduce_intervals(execution_policy<DerivedPolicy> &,
 
   index_type n = static_cast<index_type>(decomp.size());
 
-#if (THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE == THRUST_TRUE)
-# pragma omp parallel for
-#endif // THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE
+  THRUST_PRAGMA_OMP(parallel for)
   for(index_type i = 0; i < n; i++)
   {
     InputIterator begin = input + decomp[i].begin();

--- a/thrust/system/omp/detail/sort.inl
+++ b/thrust/system/omp/detail/sort.inl
@@ -113,13 +113,12 @@ void stable_sort(execution_policy<DerivedPolicy> &exec,
   , "OpenMP compiler support is not enabled"
   );
 
-#if (THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE == THRUST_TRUE)
   typedef typename thrust::iterator_difference<RandomAccessIterator>::type IndexType;
-  
+
   if(first == last)
     return;
 
-  #pragma omp parallel
+  THRUST_PRAGMA_OMP(parallel)
   {
     thrust::system::detail::internal::uniform_decomposition<IndexType> decomp(last - first, 1, omp_get_num_threads());
 
@@ -135,7 +134,7 @@ void stable_sort(execution_policy<DerivedPolicy> &exec,
                           comp);
     }
 
-    #pragma omp barrier
+    THRUST_PRAGMA_OMP(barrier)
 
     // XXX For some reason, MSVC 2015 yields an error unless we include this meaningless semicolon here
     ;
@@ -166,10 +165,9 @@ void stable_sort(execution_policy<DerivedPolicy> &exec,
       nseg = (nseg + 1) / 2;
       h *= 2;
 
-      #pragma omp barrier
+      THRUST_PRAGMA_OMP(barrier)
     }
   }
-#endif // THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE
 }
 
 
@@ -195,13 +193,12 @@ void stable_sort_by_key(execution_policy<DerivedPolicy> &exec,
   , "OpenMP compiler support is not enabled"
   );
 
-#if (THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE == THRUST_TRUE)
   typedef typename thrust::iterator_difference<RandomAccessIterator1>::type IndexType;
-  
+
   if(keys_first == keys_last)
     return;
 
-  #pragma omp parallel
+  THRUST_PRAGMA_OMP(parallel)
   {
     thrust::system::detail::internal::uniform_decomposition<IndexType> decomp(keys_last - keys_first, 1, omp_get_num_threads());
 
@@ -218,7 +215,7 @@ void stable_sort_by_key(execution_policy<DerivedPolicy> &exec,
                                  comp);
     }
 
-    #pragma omp barrier
+    THRUST_PRAGMA_OMP(barrier)
 
     // XXX For some reason, MSVC 2015 yields an error unless we include this meaningless semicolon here
     ;
@@ -250,10 +247,9 @@ void stable_sort_by_key(execution_policy<DerivedPolicy> &exec,
       nseg = (nseg + 1) / 2;
       h *= 2;
 
-      #pragma omp barrier
+      THRUST_PRAGMA_OMP(barrier)
     }
   }
-#endif // THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE
 }
 
 


### PR DESCRIPTION
Sends all `#pragma omp ...` directives through a new customization point, `THRUST_PRAGMA_OMP(...)`.

Several checks for `THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE` have been removed. These are no longer necessary since the new customization point won't emit any pragmas when OpenMP is disabled.

Fixed a conversion warning in the `sequence.cu` test that started appearing after this change.

cc: @dkolsen-pgi @zkhatami