### PR TITLE
Fix 32-bit MSVC builds.

### DIFF
--- a/thrust/system/cuda/memory_resource.h
+++ b/thrust/system/cuda/memory_resource.h
@@ -42,8 +42,8 @@ namespace cuda
 namespace detail
 {
 
-    typedef cudaError_t (*allocation_fn)(void **, std::size_t);
-    typedef cudaError_t (*deallocation_fn)(void *);
+    typedef cudaError_t (CUDARTAPI *allocation_fn)(void **, std::size_t);
+    typedef cudaError_t (CUDARTAPI *deallocation_fn)(void *);
 
     template<allocation_fn Alloc, deallocation_fn Dealloc, typename Pointer>
     class cuda_memory_resource final : public mr::memory_resource<Pointer>
@@ -79,7 +79,7 @@ namespace detail
         }
     };
 
-    inline cudaError_t cudaMallocManaged(void ** ptr, std::size_t bytes)
+    inline cudaError_t CUDARTAPI cudaMallocManaged(void ** ptr, std::size_t bytes)
     {
         return ::cudaMallocManaged(ptr, bytes, cudaMemAttachGlobal);
     }


### PR DESCRIPTION
CUDA runtime functions are annotated with CUDARTAPI, which expands to
__stdcall on MSVC.

`thrust/system/cuda/memory_resource.h` defines some
function pointer types intended for use with CUDART memory
allocation/deallocation functions, but they lack the CUDARTAPI markup.

Added this markup to fix 32-bit builds. Repro'd issue and validated
fix on MSVC 2019.

Fixes #1458.