### PR TITLE
Add make_tagged_iterator

### DIFF
--- a/thrust/iterator/detail/tagged_iterator.h
+++ b/thrust/iterator/detail/tagged_iterator.h
@@ -58,6 +58,21 @@ template<typename Iterator, typename Tag>
       : super_t(x) {}
 }; // end tagged_iterator
 
+/*! \p make_tagged_iterator creates a \p tagged_iterator
+ *  from a \c Iterator with system tag \c Tag.
+ *
+ *  \tparam Tag Any system tag.
+ *  \tparam Iterator Any iterator type.
+ *  \param iter The iterator of interest.
+ *  \return An iterator whose system tag is \p Tag and whose behavior is otherwise
+ *          equivalent to \p iter.
+ */
+template <typename Tag, typename Iterator>
+inline auto make_tagged_iterator(Iterator iter)
+{
+  return tagged_iterator<Iterator, Tag>(iter);
+}
+
 } // end detail
 
 // tagged_iterator is trivial if its base iterator is.

--- a/thrust/iterator/detail/tagged_iterator.h
+++ b/thrust/iterator/detail/tagged_iterator.h
@@ -68,7 +68,7 @@ template<typename Iterator, typename Tag>
  *          equivalent to \p iter.
  */
 template <typename Tag, typename Iterator>
-inline auto make_tagged_iterator(Iterator iter)
+inline auto make_tagged_iterator(Iterator iter) -> tagged_iterator<Iterator, Tag>
 {
   return tagged_iterator<Iterator, Tag>(iter);
 }


### PR DESCRIPTION
`make_tagged_iterator<Tag, Iterator>(iterator);`
tparam `Iterator` could be skipped due to function template type deduction.

Example usage:
```
  auto d_iter =
    thrust::detail::make_tagged_iterator<thrust::device_system_tag>(
      thrust::make_transform_iterator(
        thrust::make_counting_iterator(0), 
          [] __device__(int i) -> int { return i % 3; }));
```
