### PR TITLE
Workaround nvcxx compiler error.

### DIFF
--- a/thrust/system/cuda/detail/extrema.h
+++ b/thrust/system/cuda/detail/extrema.h
@@ -130,8 +130,11 @@ namespace __extrema {
       pair_type const &lhs_min = get<0>(lhs);
       pair_type const &rhs_max = get<1>(rhs);
       pair_type const &lhs_max = get<1>(lhs);
-      return thrust::make_tuple(arg_min_t(predicate)(lhs_min, rhs_min),
-                                arg_max_t(predicate)(lhs_max, rhs_max));
+
+      auto result = thrust::make_tuple(arg_min_t(predicate)(lhs_min, rhs_min),
+                                       arg_max_t(predicate)(lhs_max, rhs_max));
+
+      return result;
     }
 
     struct duplicate_tuple


### PR DESCRIPTION
This resolves the following error on nvcxx 22.1:

```
nvdd-Fatal-/opt/nvidia/hpc_sdk/Linux_x86_64/22.1/compilers/bin/tools/nvvmd TERMINATED by signal 11
Arguments to /opt/nvidia/hpc_sdk/Linux_x86_64/22.1/compilers/bin/tools/nvvmd
/opt/nvidia/hpc_sdk/Linux_x86_64/22.1/compilers/bin/tools/nvvmd -opt=3 -arch=compute_80 -ftz=0 -prec-div=1 -prec-sqrt=1 -fma=1 /tmp/pgaccTzSchA7vvoIJ.gpu /opt/nvidia/hpc_sdk/Linux_x86_64/22.1/cuda/11.5/nvvm/libdevice/libdevice.10.bc /opt/nvidia/hpc_sdk/Linux_x86_64/22.1/compilers/lib/nvvm70/nvhpc_cuda_runtime_cc80.ll /opt/nvidia/hpc_sdk/Linux_x86_64/22.1/compilers/lib/nvvm70/nvhpc_curand_runtime.ll /opt/nvidia/hpc_sdk/Linux_x86_64/22.1/compilers/lib/nvvm70/nvhpc_nvshmem_runtime.ll /opt/nvidia/hpc_sdk/Linux_x86_64/22.1/compilers/lib/nvvm70/nvhpc_utils_runtime.ll /opt/nvidia/hpc_sdk/Linux_x86_64/22.1/compilers/lib/nvvm70/nvhpc_cuda_wmma_runtime_cc80.ll -ptx /tmp/pgacc9zSc3cmTLiu1.ptx
NVC++-F-0155-Compiler failed to translate accelerator region (see -Minfo messages): Device compiler exited with error status code (/workspace/testing/minmax_element.cu: 1)
NVC++/x86-64 Linux 22.1-0: compilation aborted
make[2]: *** [testing/CMakeFiles/thrust.cpp.cuda.cpp17.test.minmax_element.dir/build.make:75: testing/CMakeFiles/thrust.cpp.cuda.cpp17.test.minmax_element.dir/minmax_element.cu.o] Error 2
make[2]: Target 'testing/CMakeFiles/thrust.cpp.cuda.cpp17.test.minmax_element.dir/build' not remade because of errors.
make[1]: *** [CMakeFiles/Makefile2:6124: testing/CMakeFiles/thrust.cpp.cuda.cpp17.test.minmax_element.dir/all] Error 2
```

@dkolsen-pgi FYI