### PR TITLE
Add libcu++ dependency; initial round of `NV_IF_TARGET` ports.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cub"]
 	path = dependencies/cub
 	url = ../cub.git
+[submodule "libcudacxx"]
+	path = dependencies/libcudacxx
+	url = ../libcudacxx.git

--- a/testing/allocator.cu
+++ b/testing/allocator.cu
@@ -2,6 +2,9 @@
 #include <thrust/detail/config.h>
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/system/cpp/vector.h>
+
+#include <nv/target>
+
 #include <memory>
 
 template <typename T>
@@ -80,9 +83,7 @@ struct my_allocator_with_custom_destroy
   __host__ __device__
   void destroy(T *)
   {
-#if !__CUDA_ARCH__
-    g_state = true;
-#endif
+    NV_IF_TARGET(NV_IS_HOST, (g_state = true;));
   }
 
   value_type *allocate(std::ptrdiff_t n)
@@ -203,7 +204,6 @@ void TestAllocatorTraitsRebind()
 }
 DECLARE_UNITTEST(TestAllocatorTraitsRebind);
 
-#if THRUST_CPP_DIALECT >= 2011
 void TestAllocatorTraitsRebindCpp11()
 {
   ASSERT_EQUAL(
@@ -251,5 +251,3 @@ void TestAllocatorTraitsRebindCpp11()
   );
 }
 DECLARE_UNITTEST(TestAllocatorTraitsRebindCpp11);
-#endif // C++11
-

--- a/testing/allocator.cu
+++ b/testing/allocator.cu
@@ -63,9 +63,12 @@ DECLARE_VARIABLE_UNITTEST(TestAllocatorCustomCopyConstruct);
 template <typename T>
 struct my_allocator_with_custom_destroy
 {
-  typedef T         value_type;
-  typedef T &       reference;
-  typedef const T & const_reference;
+  // This is only used with thrust::cpp::vector:
+  using system_type = thrust::cpp::tag;
+
+  using value_type = T;
+  using reference = T &;
+  using const_reference = const T &;
 
   static bool g_state;
 
@@ -120,12 +123,14 @@ bool my_allocator_with_custom_destroy<T>::g_state = false;
 template <typename T>
 void TestAllocatorCustomDestroy(size_t n)
 {
+  my_allocator_with_custom_destroy<T>::g_state = false;
+
   {
     thrust::cpp::vector<T, my_allocator_with_custom_destroy<T> > vec(n);
   } // destroy everything
 
-  if (0 < n)
-    ASSERT_EQUAL(true, my_allocator_with_custom_destroy<T>::g_state);
+  // state should only be true when there are values to destroy:
+  ASSERT_EQUAL(n > 0, my_allocator_with_custom_destroy<T>::g_state);
 }
 DECLARE_VARIABLE_UNITTEST(TestAllocatorCustomDestroy);
 

--- a/testing/cuda/pair_sort.cu
+++ b/testing/cuda/pair_sort.cu
@@ -4,16 +4,11 @@
 #include <thrust/execution_policy.h>
 
 
-template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
+template<typename ExecutionPolicy, typename Iterator>
 __global__
-void stable_sort_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 is_supported)
+void stable_sort_kernel(ExecutionPolicy exec, Iterator first, Iterator last)
 {
-#if (__CUDA_ARCH__ >= 200)
-  *is_supported = true;
   thrust::stable_sort(exec, first, last);
-#else
-  *is_supported = false;
-#endif
 }
 
 
@@ -43,19 +38,14 @@ void TestPairStableSortDevice(ExecutionPolicy exec)
 
   thrust::device_vector<P> d_pairs = h_pairs;
 
-  thrust::device_vector<bool> is_supported(1);
-
-  stable_sort_kernel<<<1,1>>>(exec, d_pairs.begin(), d_pairs.end(), is_supported.begin());
+  stable_sort_kernel<<<1,1>>>(exec, d_pairs.begin(), d_pairs.end());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
-  if(is_supported[0])
-  {
-    // sort on the host
-    thrust::stable_sort(h_pairs.begin(), h_pairs.end());
+  // sort on the host
+  thrust::stable_sort(h_pairs.begin(), h_pairs.end());
 
-    ASSERT_EQUAL_QUIET(h_pairs, d_pairs);
-  }
+  ASSERT_EQUAL_QUIET(h_pairs, d_pairs);
 };
 
 

--- a/testing/cuda/partition.cu
+++ b/testing/cuda/partition.cu
@@ -286,16 +286,11 @@ void TestPartitionCopyStencilDeviceNoSync()
 DECLARE_UNITTEST(TestPartitionCopyStencilDeviceNoSync);
 
 
-template<typename ExecutionPolicy, typename Iterator1, typename Predicate, typename Iterator2, typename Iterator3>
+template<typename ExecutionPolicy, typename Iterator1, typename Predicate, typename Iterator2>
 __global__
-void stable_partition_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Predicate pred, Iterator2 result, Iterator3 is_supported)
+void stable_partition_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Predicate pred, Iterator2 result)
 {
-#if (__CUDA_ARCH__ >= 200)
-  *is_supported = true;
   *result = thrust::stable_partition(exec, first, last, pred);
-#else
-  *is_supported = false;
-#endif
 }
 
 
@@ -313,24 +308,20 @@ void TestStablePartitionDevice(ExecutionPolicy exec)
   data[4] = 2; 
 
   thrust::device_vector<iterator> result(1);
-  thrust::device_vector<bool> is_supported(1);
-  
-  stable_partition_kernel<<<1,1>>>(exec, data.begin(), data.end(), is_even<T>(), result.begin(), is_supported.begin());
+
+  stable_partition_kernel<<<1,1>>>(exec, data.begin(), data.end(), is_even<T>(), result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
   
-  if(is_supported[0])
-  {
-    thrust::device_vector<T> ref(5);
-    ref[0] = 2;
-    ref[1] = 2;
-    ref[2] = 1;
-    ref[3] = 1;
-    ref[4] = 1;
+  thrust::device_vector<T> ref(5);
+  ref[0] = 2;
+  ref[1] = 2;
+  ref[2] = 1;
+  ref[3] = 1;
+  ref[4] = 1;
     
-    ASSERT_EQUAL(2, (iterator)result[0] - data.begin());
-    ASSERT_EQUAL(ref, data);
-  }
+  ASSERT_EQUAL(2, (iterator)result[0] - data.begin());
+  ASSERT_EQUAL(ref, data);
 }
 
 
@@ -355,16 +346,11 @@ void TestStablePartitionDeviceNoSync()
 DECLARE_UNITTEST(TestStablePartitionDeviceNoSync);
 
 
-template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Predicate, typename Iterator3, typename Iterator4>
+template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Predicate, typename Iterator3>
 __global__
-void stable_partition_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 stencil_first, Predicate pred, Iterator3 result, Iterator4 is_supported)
+void stable_partition_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 stencil_first, Predicate pred, Iterator3 result)
 {
-#if (__CUDA_ARCH__ >= 200)
-  *is_supported = true;
   *result = thrust::stable_partition(exec, first, last, stencil_first, pred);
-#else
-  *is_supported = false;
-#endif
 }
 
 
@@ -389,24 +375,20 @@ void TestStablePartitionStencilDevice(ExecutionPolicy exec)
   stencil[4] = 2; 
 
   thrust::device_vector<iterator> result(1);
-  thrust::device_vector<bool> is_supported(1);
-  
-  stable_partition_kernel<<<1,1>>>(exec, data.begin(), data.end(), stencil.begin(), is_even<T>(), result.begin(), is_supported.begin());
+
+  stable_partition_kernel<<<1,1>>>(exec, data.begin(), data.end(), stencil.begin(), is_even<T>(), result.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
   
-  if(is_supported[0])
-  {
-    thrust::device_vector<T> ref(5);
-    ref[0] = 1;
-    ref[1] = 1;
-    ref[2] = 0;
-    ref[3] = 0;
-    ref[4] = 0;
+  thrust::device_vector<T> ref(5);
+  ref[0] = 1;
+  ref[1] = 1;
+  ref[2] = 0;
+  ref[3] = 0;
+  ref[4] = 0;
     
-    ASSERT_EQUAL(2, (iterator)result[0] - data.begin());
-    ASSERT_EQUAL(ref, data);
-  }
+  ASSERT_EQUAL(2, (iterator)result[0] - data.begin());
+  ASSERT_EQUAL(ref, data);
 }
 
 

--- a/testing/cuda/sort.cu
+++ b/testing/cuda/sort.cu
@@ -4,16 +4,11 @@
 #include <thrust/execution_policy.h>
 
 
-template<typename ExecutionPolicy, typename Iterator, typename Compare, typename Iterator2>
+template<typename ExecutionPolicy, typename Iterator, typename Compare>
 __global__
-void sort_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Compare comp, Iterator2 is_supported)
+void sort_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Compare comp)
 {
-#if (__CUDA_ARCH__ >= 200)
-  *is_supported = true;
   thrust::sort(exec, first, last, comp);
-#else
-  *is_supported = false;
-#endif
 }
 
 
@@ -34,19 +29,14 @@ void TestComparisonSortDevice(ExecutionPolicy exec, const size_t n, Compare comp
   thrust::host_vector<T>   h_data = unittest::random_integers<T>(n);
   thrust::device_vector<T> d_data = h_data;
   
-  thrust::device_vector<bool> is_supported(1);
-
-  sort_kernel<<<1,1>>>(exec, d_data.begin(), d_data.end(), comp, is_supported.begin());
+  sort_kernel<<<1,1>>>(exec, d_data.begin(), d_data.end(), comp);
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
 
-  if(is_supported[0])
-  {
-    thrust::sort(h_data.begin(), h_data.end(), comp);
-    
-    ASSERT_EQUAL(h_data, d_data);
-  }
+  thrust::sort(h_data.begin(), h_data.end(), comp);
+
+  ASSERT_EQUAL(h_data, d_data);
 };
 
 
@@ -163,7 +153,7 @@ void TestComparisonSortCudaStreams()
   cudaStreamSynchronize(s);
 
   ASSERT_EQUAL(true, thrust::is_sorted(keys.begin(), keys.end(), my_less<int>()));
-                      
+
   cudaStreamDestroy(s);
 }
 DECLARE_UNITTEST(TestComparisonSortCudaStreams);

--- a/testing/device_delete.cu
+++ b/testing/device_delete.cu
@@ -4,21 +4,23 @@
 #include <thrust/device_new.h>
 #include <thrust/device_delete.h>
 
+#include <nv/target>
+
 struct Foo
 {
   __host__ __device__
   Foo(void)
-    :set_me_upon_destruction(0)
+    : set_me_upon_destruction{nullptr}
   {}
 
   __host__ __device__
   ~Foo(void)
   {
-#ifdef __CUDA_ARCH__
-    // __device__ overload
-    if(set_me_upon_destruction != 0)
-      *set_me_upon_destruction = true;
-#endif
+    NV_IF_TARGET(NV_IS_DEVICE, (
+      if (set_me_upon_destruction != nullptr)
+      {
+        *set_me_upon_destruction = true;
+      }));
   }
 
   bool *set_me_upon_destruction;

--- a/testing/uninitialized_copy.cu
+++ b/testing/uninitialized_copy.cu
@@ -3,6 +3,7 @@
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/iterator/retag.h>
 
+#include <nv/target>
 
 template<typename InputIterator, typename ForwardIterator>
 ForwardIterator uninitialized_copy(my_system &system,
@@ -147,13 +148,13 @@ struct CopyConstructTest
   __host__ __device__
   CopyConstructTest(const CopyConstructTest &)
   {
-#if __CUDA_ARCH__
-    copy_constructed_on_device = true;
-    copy_constructed_on_host   = false;
-#else
-    copy_constructed_on_device = false;
-    copy_constructed_on_device = true;
-#endif
+    NV_IF_TARGET(NV_IS_DEVICE, (
+      copy_constructed_on_device = true;
+      copy_constructed_on_host   = false;
+    ), (
+      copy_constructed_on_device = false;
+      copy_constructed_on_host = true;
+    ));
   }
 
   __host__ __device__

--- a/testing/uninitialized_fill.cu
+++ b/testing/uninitialized_fill.cu
@@ -3,6 +3,7 @@
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/iterator/retag.h>
 
+#include <nv/target>
 
 template<typename ForwardIterator, typename T>
 void uninitialized_fill(my_system &system,
@@ -156,13 +157,13 @@ struct CopyConstructTest
   __host__ __device__
   CopyConstructTest(const CopyConstructTest &)
   {
-#if __CUDA_ARCH__
-    copy_constructed_on_device = true;
-    copy_constructed_on_host   = false;
-#else
-    copy_constructed_on_device = false;
-    copy_constructed_on_host   = true;
-#endif
+    NV_IF_TARGET(NV_IS_DEVICE, (
+      copy_constructed_on_device = true;
+      copy_constructed_on_host   = false;
+    ), (
+      copy_constructed_on_device = false;
+      copy_constructed_on_host   = true;
+    ));
   }
 
   __host__ __device__

--- a/testing/unittest/cuda/testframework.cu
+++ b/testing/unittest/cuda/testframework.cu
@@ -137,7 +137,6 @@ bool CUDATestDriver::run_tests(const ArgumentSet &args, const ArgumentMap &kwarg
   {
     std::cout << "--verbose and --concise cannot be used together" << std::endl;
     exit(EXIT_FAILURE);
-    return false;
   }
 
   // check error status before doing anything

--- a/testing/unittest/runtime_static_assert.h
+++ b/testing/unittest/runtime_static_assert.h
@@ -18,7 +18,10 @@ namespace unittest
 #include <thrust/device_new.h>
 #include <thrust/device_delete.h>
 
+#include <nv/target>
+
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+
 
 #define ASSERT_STATIC_ASSERT(X) \
     { \
@@ -86,11 +89,9 @@ namespace unittest
         {
             static_assert_exception ex(filename, lineno);
 
-#ifdef __CUDA_ARCH__
-            *detail::device_exception = ex;
-#else
-            throw ex;
-#endif
+            NV_IF_TARGET(NV_IS_DEVICE,
+                         (*detail::device_exception = ex;),
+                         (throw ex;));
         }
     }
 }

--- a/thrust/cmake/README.md
+++ b/thrust/cmake/README.md
@@ -101,7 +101,7 @@ find_package(Thrust 1.9.10.1 EXACT)
 
 would only match the 1.9.10.1 release.
 
-#### Using a Specific TBB or OpenMP Environment
+#### Using an Explicit TBB or OpenMP CMake Target
 
 When `thrust_create_target` is called, it will lazily load the requested
 systems on-demand through internal `find_package` calls. If a project already
@@ -112,9 +112,20 @@ thrust_set_TBB_target(MyTBBTarget)
 thrust_set_OMP_target(MyOMPTarget)
 ```
 
-These functions must be called **before** `thrust_create_target`, and will
-have no effect if the dependency is loaded as a
-`find_package(Thrust COMPONENT [...])` component.
+These functions must be called **before** the corresponding system is loaded
+through `thrust_create_target` or `find_package(Thrust COMPONENT [OMP|TBB])`.
+
+#### Using an Explicit libcu++ CMake Target
+
+In contrast to the optional TBB/OMP dependencies, there is no
+`thrust_set_libcudacxx_target` function that specifies an explicit libcu++
+target. This is because libcu++ is always required and must be found during the
+initial `find_target(Thrust)` call that defines these functions.
+
+To force Thrust to use a specific libcu++ target, ensure that either the
+`Thrust::libcudacxx` or `libcudacxx::libcudacxx` targets are defined prior to
+the first invocation of `find_package(Thrust)`. Thrust will automatically use
+these, giving preference to the `Thrust::libcudacxx` target.
 
 #### Testing for Systems
 

--- a/thrust/cmake/thrust-config.cmake
+++ b/thrust/cmake/thrust-config.cmake
@@ -89,19 +89,21 @@ set(thrust_libcudacxx_version 1.8.0)
 set(THRUST_HOST_SYSTEM_OPTIONS
   CPP OMP TBB
   CACHE INTERNAL "Valid Thrust host systems."
+  FORCE
 )
 set(THRUST_DEVICE_SYSTEM_OPTIONS
   CUDA CPP OMP TBB
   CACHE INTERNAL "Valid Thrust device systems"
+  FORCE
 )
 
 # Workaround cmake issue #20670 https://gitlab.kitware.com/cmake/cmake/-/issues/20670
-set(THRUST_VERSION ${${CMAKE_FIND_PACKAGE_NAME}_VERSION} CACHE INTERNAL "")
-set(THRUST_VERSION_MAJOR ${${CMAKE_FIND_PACKAGE_NAME}_VERSION_MAJOR} CACHE INTERNAL "")
-set(THRUST_VERSION_MINOR ${${CMAKE_FIND_PACKAGE_NAME}_VERSION_MINOR} CACHE INTERNAL "")
-set(THRUST_VERSION_PATCH ${${CMAKE_FIND_PACKAGE_NAME}_VERSION_PATCH} CACHE INTERNAL "")
-set(THRUST_VERSION_TWEAK ${${CMAKE_FIND_PACKAGE_NAME}_VERSION_TWEAK} CACHE INTERNAL "")
-set(THRUST_VERSION_COUNT ${${CMAKE_FIND_PACKAGE_NAME}_VERSION_COUNT} CACHE INTERNAL "")
+set(THRUST_VERSION ${${CMAKE_FIND_PACKAGE_NAME}_VERSION} CACHE INTERNAL "" FORCE)
+set(THRUST_VERSION_MAJOR ${${CMAKE_FIND_PACKAGE_NAME}_VERSION_MAJOR} CACHE INTERNAL "" FORCE)
+set(THRUST_VERSION_MINOR ${${CMAKE_FIND_PACKAGE_NAME}_VERSION_MINOR} CACHE INTERNAL "" FORCE)
+set(THRUST_VERSION_PATCH ${${CMAKE_FIND_PACKAGE_NAME}_VERSION_PATCH} CACHE INTERNAL "" FORCE)
+set(THRUST_VERSION_TWEAK ${${CMAKE_FIND_PACKAGE_NAME}_VERSION_TWEAK} CACHE INTERNAL "" FORCE)
+set(THRUST_VERSION_COUNT ${${CMAKE_FIND_PACKAGE_NAME}_VERSION_COUNT} CACHE INTERNAL "" FORCE)
 
 function(thrust_create_target target_name)
   thrust_debug("Assembling target ${target_name}. Options: ${ARGN}" internal)
@@ -113,7 +115,7 @@ function(thrust_create_target target_name)
     IGNORE_DEPRECATED_COMPILER
     IGNORE_DEPRECATED_CPP_11
     IGNORE_DEPRECATED_CPP_DIALECT
-    )
+  )
   set(keys
     DEVICE
     DEVICE_OPTION
@@ -121,13 +123,13 @@ function(thrust_create_target target_name)
     HOST
     HOST_OPTION
     HOST_OPTION_DOC
-    )
+  )
   cmake_parse_arguments(TCT "${options}" "${keys}" "" ${ARGN})
   if (TCT_UNPARSED_ARGUMENTS)
     message(AUTHOR_WARNING
       "Unrecognized arguments passed to thrust_create_target: "
       ${TCT_UNPARSED_ARGUMENTS}
-      )
+    )
   endif()
 
   # Check that the main Thrust internal target is available
@@ -137,7 +139,7 @@ function(thrust_create_target target_name)
     message(AUTHOR_WARNING
       "The `thrust_create_target` function was called outside the scope of the "
       "thrust targets. Call find_package again to recreate targets."
-      )
+    )
   endif()
 
   _thrust_set_if_undefined(TCT_HOST CPP)
@@ -149,12 +151,14 @@ function(thrust_create_target target_name)
 
   if (NOT TCT_HOST IN_LIST THRUST_HOST_SYSTEM_OPTIONS)
     message(FATAL_ERROR
-      "Requested HOST=${TCT_HOST}; must be one of ${THRUST_HOST_SYSTEM_OPTIONS}")
+      "Requested HOST=${TCT_HOST}; must be one of ${THRUST_HOST_SYSTEM_OPTIONS}"
+    )
   endif()
 
   if (NOT TCT_DEVICE IN_LIST THRUST_DEVICE_SYSTEM_OPTIONS)
     message(FATAL_ERROR
-      "Requested DEVICE=${TCT_DEVICE}; must be one of ${THRUST_DEVICE_SYSTEM_OPTIONS}")
+      "Requested DEVICE=${TCT_DEVICE}; must be one of ${THRUST_DEVICE_SYSTEM_OPTIONS}"
+    )
   endif()
 
   if (TCT_FROM_OPTIONS)
@@ -176,7 +180,7 @@ function(thrust_create_target target_name)
 
   # We can just create an INTERFACE IMPORTED target here instead of going
   # through _thrust_declare_interface_alias as long as we aren't hanging any
-  # Thrust/CUB include paths on ${target_name}.
+  # Thrust/CUB include paths directly on ${target_name}.
   add_library(${target_name} INTERFACE IMPORTED)
   target_link_libraries(${target_name}
     INTERFACE
@@ -479,7 +483,10 @@ function(thrust_set_TBB_target tbb_target)
   if (NOT TARGET Thrust::TBB)
     thrust_debug("Setting TBB target to ${tbb_target}" internal)
     # Workaround cmake issue #20670 https://gitlab.kitware.com/cmake/cmake/-/issues/20670
-    set(THRUST_TBB_VERSION ${TBB_VERSION} CACHE INTERNAL "TBB version used by Thrust")
+    set(THRUST_TBB_VERSION ${TBB_VERSION} CACHE INTERNAL
+      "TBB version used by Thrust"
+      FORCE
+    )
     _thrust_declare_interface_alias(Thrust::TBB _Thrust_TBB)
     target_link_libraries(_Thrust_TBB INTERFACE Thrust::Thrust ${tbb_target})
     thrust_debug_target(${tbb_target} "${THRUST_TBB_VERSION}" internal)
@@ -494,7 +501,10 @@ function(thrust_set_OMP_target omp_target)
   if (NOT TARGET Thrust::OMP)
     thrust_debug("Setting OMP target to ${omp_target}" internal)
     # Workaround cmake issue #20670 https://gitlab.kitware.com/cmake/cmake/-/issues/20670
-    set(THRUST_OMP_VERSION ${OpenMP_CXX_VERSION} CACHE INTERNAL "OpenMP version used by Thrust")
+    set(THRUST_OMP_VERSION ${OpenMP_CXX_VERSION} CACHE INTERNAL
+      "OpenMP version used by Thrust"
+      FORCE
+    )
     _thrust_declare_interface_alias(Thrust::OMP _Thrust_OMP)
     target_link_libraries(_Thrust_OMP INTERFACE Thrust::Thrust ${omp_target})
     thrust_debug_target(${omp_target} "${THRUST_OMP_VERSION}" internal)
@@ -653,14 +663,17 @@ endmacro()
 #
 
 if (${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
-  set(_THRUST_QUIET ON CACHE INTERNAL "Quiet mode enabled for Thrust find_package calls.")
-  set(_THRUST_QUIET_FLAG "QUIET" CACHE INTERNAL "")
+  set(_THRUST_QUIET ON CACHE INTERNAL "Quiet mode enabled for Thrust find_package calls." FORCE)
+  set(_THRUST_QUIET_FLAG "QUIET" CACHE INTERNAL "" FORCE)
 else()
   unset(_THRUST_QUIET CACHE)
   unset(_THRUST_QUIET_FLAG CACHE)
 endif()
 
-set(_THRUST_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "Location of thrust-config.cmake")
+set(_THRUST_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL
+  "Location of thrust-config.cmake"
+  FORCE
+)
 
 # Internal target that actually holds the Thrust interface. Used by all other Thrust targets.
 if (NOT TARGET Thrust::Thrust)
@@ -668,6 +681,7 @@ if (NOT TARGET Thrust::Thrust)
   # Pull in the include dir detected by thrust-config-version.cmake
   set(_THRUST_INCLUDE_DIR "${_THRUST_VERSION_INCLUDE_DIR}"
     CACHE INTERNAL "Location of Thrust headers."
+    FORCE
   )
   unset(_THRUST_VERSION_INCLUDE_DIR CACHE) # Clear tmp variable from cache
   target_include_directories(_Thrust_Thrust INTERFACE "${_THRUST_INCLUDE_DIR}")

--- a/thrust/cmake/thrust-config.cmake
+++ b/thrust/cmake/thrust-config.cmake
@@ -37,15 +37,14 @@
 #   [ADVANCED]                       # Optionally mark options as advanced
 # )
 #
-# # Use a custom TBB, CUB, libcudacxx, and/or OMP
+# # Use a custom TBB, CUB, and/or OMP
 # # (Note that once set, these cannot be changed. This includes COMPONENT
 # # preloading and lazy lookups in thrust_create_target)
 # find_package(Thrust REQUIRED)
 # thrust_set_CUB_target(MyCUBTarget)  # MyXXXTarget contains an existing
 # thrust_set_TBB_target(MyTBBTarget)  # interface to XXX for Thrust to use.
-# thrust_set_libcudacxx_target(MyLibcudacxxTarget)
 # thrust_set_OMP_target(MyOMPTarget)
-# thrust_create_target(ThrustWithMyCUBAndLibcudacxx DEVICE CUDA)
+# thrust_create_target(ThrustWithMyCUB DEVICE CUDA)
 # thrust_create_target(ThrustWithMyTBB DEVICE TBB)
 # thrust_create_target(ThrustWithMyOMP DEVICE OMP)
 #
@@ -460,9 +459,10 @@ function(thrust_set_CUB_target cub_target)
   endif()
 endfunction()
 
-# Use the provided libcudacxx_target for the CUDA backend. If Thrust::libcudacxx
-# already exists, this call has no effect.
-function(thrust_set_libcudacxx_target libcudacxx_target)
+# Internal use only -- libcudacxx must be found during the initial
+# `find_package(Thrust)` call and cannot be set afterwards. See README.md in
+# this directory for details on using a specific libcudacxx target.
+function(_thrust_set_libcudacxx_target libcudacxx_target)
   if (NOT TARGET Thrust::libcudacxx)
     thrust_debug("Setting libcudacxx target to ${libcudacxx_target}" internal)
     # Workaround cmake issue #20670 https://gitlab.kitware.com/cmake/cmake/-/issues/20670
@@ -712,7 +712,7 @@ if (NOT TARGET Thrust::libcudacxx)
   )
 
   if (TARGET libcudacxx::libcudacxx)
-    thrust_set_libcudacxx_target(libcudacxx::libcudacxx)
+    _thrust_set_libcudacxx_target(libcudacxx::libcudacxx)
   else()
     thrust_debug("Expected libcudacxx::libcudacxx target not found!" internal)
   endif()

--- a/thrust/detail/allocator/no_throw_allocator.h
+++ b/thrust/detail/allocator/no_throw_allocator.h
@@ -18,6 +18,8 @@
 
 #include <thrust/detail/config.h>
 
+#include <nv/target>
+
 THRUST_NAMESPACE_BEGIN
 namespace detail
 {
@@ -43,18 +45,18 @@ template<typename BaseAllocator>
     __host__ __device__
     void deallocate(typename super_t::pointer p, typename super_t::size_type n)
     {
-#ifndef __CUDA_ARCH__
-      try
-      {
+      NV_IF_TARGET(NV_IS_HOST, (
+        try
+        {
+          super_t::deallocate(p, n);
+        } // end try
+        catch(...)
+        {
+          // catch anything
+        } // end catch
+      ), (
         super_t::deallocate(p, n);
-      } // end try
-      catch(...)
-      {
-        // catch anything
-      } // end catch
-#else
-      super_t::deallocate(p, n);
-#endif
+      ));
     } // end deallocate()
 
     inline __host__ __device__

--- a/thrust/detail/allocator/temporary_allocator.inl
+++ b/thrust/detail/allocator/temporary_allocator.inl
@@ -22,10 +22,13 @@
 #include <thrust/system/detail/bad_alloc.h>
 #include <cassert>
 
-#if (defined(_NVHPC_CUDA) || defined(__CUDA_ARCH__)) && \
-    THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+#include <nv/target>
+
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+#if (defined(_NVHPC_CUDA) || defined(__CUDA_ARCH__))
 #include <thrust/system/cuda/detail/terminate.h>
-#endif
+#endif // NVCC device pass or NVC++
+#endif // CUDA
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -47,15 +50,11 @@ __host__ __device__
     // note that we pass cnt to deallocate, not a value derived from result.second
     deallocate(result.first, cnt);
 
-    if (THRUST_IS_HOST_CODE) {
-      #if THRUST_INCLUDE_HOST_CODE
-        throw thrust::system::detail::bad_alloc("temporary_buffer::allocate: get_temporary_buffer failed");
-      #endif
-    } else {
-      #if THRUST_INCLUDE_DEVICE_CODE && THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-        thrust::system::cuda::detail::terminate_with_message("temporary_buffer::allocate: get_temporary_buffer failed");
-      #endif
-    }
+    NV_IF_TARGET(NV_IS_HOST, (
+      throw thrust::system::detail::bad_alloc("temporary_buffer::allocate: get_temporary_buffer failed");
+    ), ( // NV_IS_DEVICE
+      thrust::system::cuda::detail::terminate_with_message("temporary_buffer::allocate: get_temporary_buffer failed");
+    ));
   } // end if
 
   return result.first;

--- a/thrust/detail/config/cpp_compatibility.h
+++ b/thrust/detail/config/cpp_compatibility.h
@@ -73,20 +73,29 @@
 #  endif
 #endif
 
-#if defined(_NVHPC_CUDA)
-#  define THRUST_IS_DEVICE_CODE __builtin_is_device_code()
-#  define THRUST_IS_HOST_CODE (!__builtin_is_device_code())
-#  define THRUST_INCLUDE_DEVICE_CODE 1
-#  define THRUST_INCLUDE_HOST_CODE 1
-#elif defined(__CUDA_ARCH__)
-#  define THRUST_IS_DEVICE_CODE 1
-#  define THRUST_IS_HOST_CODE 0
-#  define THRUST_INCLUDE_DEVICE_CODE 1
-#  define THRUST_INCLUDE_HOST_CODE 0
-#else
-#  define THRUST_IS_DEVICE_CODE 0
-#  define THRUST_IS_HOST_CODE 1
-#  define THRUST_INCLUDE_DEVICE_CODE 0
-#  define THRUST_INCLUDE_HOST_CODE 1
-#endif
-
+// These definitions were intended for internal use only and are now obsolete.
+// If you relied on them, consider porting your code to use the functionality
+// in libcu++'s <nv/target> header.
+// For a temporary workaround, define THRUST_PROVIDE_LEGACY_ARCH_MACROS to make
+// them available again. These should be considered deprecated and will be
+// fully removed in a future version.
+#ifdef THRUST_PROVIDE_LEGACY_ARCH_MACROS
+  #ifndef THRUST_IS_DEVICE_CODE
+    #if defined(_NVHPC_CUDA)
+      #define THRUST_IS_DEVICE_CODE __builtin_is_device_code()
+      #define THRUST_IS_HOST_CODE (!__builtin_is_device_code())
+      #define THRUST_INCLUDE_DEVICE_CODE 1
+      #define THRUST_INCLUDE_HOST_CODE 1
+    #elif defined(__CUDA_ARCH__)
+      #define THRUST_IS_DEVICE_CODE 1
+      #define THRUST_IS_HOST_CODE 0
+      #define THRUST_INCLUDE_DEVICE_CODE 1
+      #define THRUST_INCLUDE_HOST_CODE 0
+    #else
+      #define THRUST_IS_DEVICE_CODE 0
+      #define THRUST_IS_HOST_CODE 1
+      #define THRUST_INCLUDE_DEVICE_CODE 0
+      #define THRUST_INCLUDE_HOST_CODE 1
+    #endif
+  #endif
+#endif // THRUST_PROVIDE_LEGACY_ARCH_MACROS

--- a/thrust/detail/integer_math.h
+++ b/thrust/detail/integer_math.h
@@ -17,14 +17,13 @@
 #pragma once
 
 #include <thrust/detail/config.h>
+#include <thrust/detail/type_deduction.h>
+
+#include <nv/target>
+
 #include <limits>
 
-#if THRUST_CPP_DIALECT >= 2011
-  #include <thrust/detail/type_deduction.h>
-#endif
-
 THRUST_NAMESPACE_BEGIN
-
 namespace detail
 {
 
@@ -33,25 +32,23 @@ __host__ __device__ __thrust_forceinline__
 Integer clz(Integer x)
 {
   Integer result;
-  if (THRUST_IS_DEVICE_CODE) {
-    #if THRUST_INCLUDE_DEVICE_CODE
-      result = ::__clz(x);
-    #endif
-  } else {
-    #if THRUST_INCLUDE_HOST_CODE
-      int num_bits = 8 * sizeof(Integer);
-      int num_bits_minus_one = num_bits - 1;
-      result = num_bits;
-      for (int i = num_bits_minus_one; i >= 0; --i)
+
+  NV_IF_TARGET(NV_IS_DEVICE, (
+    result = ::__clz(x);
+  ), (
+    int num_bits = 8 * sizeof(Integer);
+    int num_bits_minus_one = num_bits - 1;
+    result = num_bits;
+    for (int i = num_bits_minus_one; i >= 0; --i)
+    {
+      if ((Integer(1) << i) & x)
       {
-        if ((Integer(1) << i) & x)
-        {
-          result = num_bits_minus_one - i;
-          break;
-        }
+        result = num_bits_minus_one - i;
+        break;
       }
-    #endif
-  }
+    }
+  ));
+
   return result;
 }
 

--- a/thrust/detail/memory_algorithms.h
+++ b/thrust/detail/memory_algorithms.h
@@ -12,11 +12,14 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/detail/allocator/allocator_traits.h>
+#include <thrust/detail/memory_wrapper.h>
 #include <thrust/addressof.h>
+
+#include <nv/target>
 
 #include <utility>
 #include <new>
-#include <thrust/detail/memory_wrapper.h>
+
 
 THRUST_NAMESPACE_BEGIN
 
@@ -102,7 +105,6 @@ ForwardIt destroy_n(Allocator const& alloc, ForwardIt first, Size n)
   return first;
 }
 
-#if THRUST_CPP_DIALECT >= 2011
 template <typename ForwardIt, typename... Args>
 __host__ __device__
 void uninitialized_construct(
@@ -112,17 +114,24 @@ void uninitialized_construct(
   using T = typename iterator_traits<ForwardIt>::value_type;
 
   ForwardIt current = first;
-  #if !__CUDA_ARCH__ // No exceptions in CUDA.
-  try {
-  #endif
+
+  // No exceptions in CUDA.
+  NV_IF_TARGET(NV_IS_HOST, (
+    try {
+      for (; current != last; ++current)
+      {
+        ::new (static_cast<void*>(addressof(*current))) T(args...);
+      }
+    } catch (...) {
+      destroy(first, current);
+      throw;
+    }
+  ), (
     for (; current != last; ++current)
+    {
       ::new (static_cast<void*>(addressof(*current))) T(args...);
-  #if !__CUDA_ARCH__ // No exceptions in CUDA.
-  } catch (...) {
-    destroy(first, current);
-    throw;
-  }
-  #endif
+    }
+  ));
 }
 
 template <typename Allocator, typename ForwardIt, typename... Args>
@@ -140,17 +149,24 @@ void uninitialized_construct_with_allocator(
   typename traits::allocator_type alloc_T(alloc);
 
   ForwardIt current = first;
-  #if !__CUDA_ARCH__ // No exceptions in CUDA.
-  try {
-  #endif
+
+  // No exceptions in CUDA.
+  NV_IF_TARGET(NV_IS_HOST, (
+    try {
+      for (; current != last; ++current)
+      {
+        traits::construct(alloc_T, addressof(*current), args...);
+      }
+    } catch (...) {
+      destroy(alloc_T, first, current);
+      throw;
+    }
+  ), (
     for (; current != last; ++current)
+    {
       traits::construct(alloc_T, addressof(*current), args...);
-  #if !__CUDA_ARCH__ // No exceptions in CUDA.
-  } catch (...) {
-    destroy(alloc_T, first, current);
-    throw;
-  }
-  #endif
+    }
+  ));
 }
 
 template <typename ForwardIt, typename Size, typename... Args>
@@ -161,17 +177,24 @@ void uninitialized_construct_n(
   using T = typename iterator_traits<ForwardIt>::value_type;
 
   ForwardIt current = first;
-  #if !__CUDA_ARCH__ // No exceptions in CUDA.
-  try {
-  #endif
-    for (; n > 0; (void) ++current, --n)
+
+  // No exceptions in CUDA.
+  NV_IF_TARGET(NV_IS_HOST, (
+    try {
+      for (; n > 0; ++current, --n)
+      {
+        ::new (static_cast<void*>(addressof(*current))) T(args...);
+      }
+    } catch (...) {
+      destroy(first, current);
+      throw;
+    }
+  ), (
+    for (; n > 0; ++current, --n)
+    {
       ::new (static_cast<void*>(addressof(*current))) T(args...);
-  #if !__CUDA_ARCH__ // No exceptions in CUDA.
-  } catch (...) {
-    destroy(first, current);
-    throw;
-  }
-  #endif
+    }
+  ));
 }
 
 template <typename Allocator, typename ForwardIt, typename Size, typename... Args>
@@ -189,19 +212,25 @@ void uninitialized_construct_n_with_allocator(
   typename traits::allocator_type alloc_T(alloc);
 
   ForwardIt current = first;
-  #if !__CUDA_ARCH__ // No exceptions in CUDA.
-  try {
-  #endif
+
+  // No exceptions in CUDA.
+  NV_IF_TARGET(NV_IS_HOST, (
+    try {
+      for (; n > 0; (void) ++current, --n)
+      {
+        traits::construct(alloc_T, addressof(*current), args...);
+      }
+    } catch (...) {
+      destroy(alloc_T, first, current);
+      throw;
+    }
+  ), (
     for (; n > 0; (void) ++current, --n)
+    {
       traits::construct(alloc_T, addressof(*current), args...);
-  #if !__CUDA_ARCH__ // No exceptions in CUDA.
-  } catch (...) {
-    destroy(alloc_T, first, current);
-    throw;
-  }
-  #endif
+    }
+  ));
 }
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -568,15 +568,7 @@ template<typename T>
 
 struct largest_available_float
 {
-#if defined(__CUDA_ARCH__)
-#  if (__CUDA_ARCH__ < 130)
-  typedef float type;
-#  else
   typedef double type;
-#  endif
-#else
-  typedef double type;
-#endif
 };
 
 // T1 wins if they are both the same size

--- a/thrust/device_allocator.h
+++ b/thrust/device_allocator.h
@@ -115,7 +115,7 @@ public:
     };
 
     /*! Default constructor has no effect. */
-    __host__
+    __host__ __device__
     device_allocator() {}
 
     /*! Copy constructor has no effect. */
@@ -124,15 +124,13 @@ public:
 
     /*! Constructor from other \p device_allocator has no effect. */
     template<typename U>
-    __host__
+    __host__ __device__
     device_allocator(const device_allocator<U>& other) : base(other) {}
 
-#if THRUST_CPP_DIALECT >= 2011
     device_allocator & operator=(const device_allocator &) = default;
-#endif
 
     /*! Destructor has no effect. */
-    __host__
+    __host__ __device__
     ~device_allocator() {}
 };
 

--- a/thrust/mr/allocator.h
+++ b/thrust/mr/allocator.h
@@ -219,7 +219,8 @@ public:
     /*! Default constructor. Uses \p get_global_resource to get the global instance of \p Upstream and initializes the
      *      \p allocator base subobject with that resource.
      */
-    __host__
+    __thrust_exec_check_disable__
+    __host__ __device__
     stateless_resource_allocator() : base(get_global_resource<Upstream>())
     {
     }

--- a/thrust/system/cuda/config.h
+++ b/thrust/system/cuda/config.h
@@ -33,7 +33,7 @@
 #include <cub/util_namespace.cuh>
 
 #if defined(__CUDACC__) || defined(_NVHPC_CUDA)
-#  if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__>= 350 && defined(__CUDACC_RDC__))
+#  if !defined(__CUDA_ARCH__) || defined(__CUDACC_RDC__)
 #    define __THRUST_HAS_CUDART__ 1
 #    define THRUST_RUNTIME_FUNCTION __host__ __device__ __forceinline__
 #  else

--- a/thrust/system/cuda/config.h
+++ b/thrust/system/cuda/config.h
@@ -45,9 +45,17 @@
 #  define THRUST_RUNTIME_FUNCTION __host__ __forceinline__
 #endif
 
+// These definitions were intended for internal use only and are now obsolete.
+// If you relied on them, consider porting your code to use the functionality
+// in libcu++'s <nv/target> header.
+// For a temporary workaround, define THRUST_PROVIDE_LEGACY_ARCH_MACROS to make
+// them available again. These should be considered deprecated and will be
+// fully removed in a future version.
+#ifdef THRUST_PROVIDE_LEGACY_ARCH_MACROS
 #ifdef __CUDA_ARCH__
 #define THRUST_DEVICE_CODE
-#endif
+#endif // __CUDA_ARCH__
+#endif // THRUST_PROVIDE_LEGACY_ARCH_MACROS
 
 #ifdef THRUST_AGENT_ENTRY_NOINLINE
 #define THRUST_AGENT_ENTRY_INLINE_ATTR __noinline__

--- a/thrust/system/cuda/detail/assign_value.h
+++ b/thrust/system/cuda/detail/assign_value.h
@@ -24,6 +24,7 @@
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/system/cuda/detail/copy.h>
 
+#include <nv/target>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub {
@@ -47,15 +48,12 @@ inline __host__ __device__
     }
   };
 
-  if (THRUST_IS_HOST_CODE) {
-    #if THRUST_INCLUDE_HOST_CODE
-      war_nvbugs_881631::host_path(exec,dst,src);
-    #endif
-  } else {
-    #if THRUST_INCLUDE_DEVICE_CODE
-      war_nvbugs_881631::device_path(exec,dst,src);
-    #endif
-  }
+  NV_IF_TARGET(NV_IS_HOST, (
+    war_nvbugs_881631::host_path(exec,dst,src);
+  ), (
+    war_nvbugs_881631::device_path(exec,dst,src);
+  ));
+
 } // end assign_value()
 
 
@@ -83,18 +81,12 @@ inline __host__ __device__
     }
   };
 
-  if (THRUST_IS_HOST_CODE) {
-    #if THRUST_INCLUDE_HOST_CODE
-      war_nvbugs_881631::host_path(systems,dst,src);
-    #endif
-  } else {
-    #if THRUST_INCLUDE_DEVICE_CODE
-      war_nvbugs_881631::device_path(systems,dst,src);
-    #endif
-  }
+  NV_IF_TARGET(NV_IS_HOST, (
+    war_nvbugs_881631::host_path(systems,dst,src);
+  ), (
+    war_nvbugs_881631::device_path(systems,dst,src);
+  ));
 } // end assign_value()
-
-
 
 
 } // end cuda_cub

--- a/thrust/system/cuda/detail/core/agent_launcher.h
+++ b/thrust/system/cuda/detail/core/agent_launcher.h
@@ -36,14 +36,7 @@
 #include <thrust/system/cuda/detail/core/util.h>
 #include <cassert>
 
-#if 0
-#define __THRUST__TEMPLATE_DEBUG
-#endif
-
-#if __THRUST__TEMPLATE_DEBUG
-template<int...> class ID_impl;
-template<int... I> class Foo { ID_impl<I...> t;};
-#endif
+#include <nv/target>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub {
@@ -521,15 +514,9 @@ namespace core {
     {
       if (debug_sync)
       {
-        if (THRUST_IS_DEVICE_CODE) {
-          #if THRUST_INCLUDE_DEVICE_CODE
-            cub::detail::device_synchronize();
-          #endif
-        } else {
-          #if THRUST_INCLUDE_HOST_CODE
-            cudaStreamSynchronize(stream);
-          #endif
-        }
+        NV_IF_TARGET(NV_IS_HOST,
+                     (cudaStreamSynchronize(stream);),
+                     (cub::detail::device_synchronize();));
       }
     }
 
@@ -747,16 +734,6 @@ namespace core {
     void THRUST_RUNTIME_FUNCTION
     launch(Args... args) const
     {
-#if __THRUST__TEMPLATE_DEBUG
-#ifdef __CUDA_ARCH__
-      typedef typename Foo<
-        shm1::v1,
-        shm1::v2,
-        shm1::v3,
-        shm1::v4,
-        shm1::v5>::t tt;
-#endif
-#endif
       launch_impl(has_enough_shmem_t(),args...);
       sync();
     }

--- a/thrust/system/cuda/detail/core/util.h
+++ b/thrust/system/cuda/detail/core/util.h
@@ -601,12 +601,11 @@ namespace core {
   template <class T>
   class cuda_optional
   {
-    cudaError_t status_;
-    T           value_;
+    cudaError_t status_{cudaSuccess};
+    T           value_{};
 
   public:
-    __host__ __device__
-    cuda_optional() : status_(cudaSuccess) {}
+    cuda_optional() = default;
 
     __host__ __device__
     cuda_optional(T v, cudaError_t status = cudaSuccess) : status_(status), value_(v) {}

--- a/thrust/system/cuda/detail/get_value.h
+++ b/thrust/system/cuda/detail/get_value.h
@@ -24,6 +24,8 @@
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/iterator/iterator_traits.h>
 
+#include <nv/target>
+
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub {
 
@@ -62,24 +64,10 @@ inline __host__ __device__
     }
   };
 
-  // The usual pattern for separating host and device code doesn't work here
-  // because it would result in a compiler warning, either about falling off
-  // the end of a non-void function, or about result_type's default constructor
-  // being a host-only function.
-  #ifdef _NVHPC_CUDA
-  if (THRUST_IS_HOST_CODE) {
-    return war_nvbugs_881631::host_path(exec, ptr);
-  } else {
-    return war_nvbugs_881631::device_path(exec, ptr);
-  }
-  #else
-    #ifndef __CUDA_ARCH__
-      return war_nvbugs_881631::host_path(exec, ptr);
-    #else
-      return war_nvbugs_881631::device_path(exec, ptr);
-    #endif // __CUDA_ARCH__
-  #endif
-  } // end get_value_msvc2005_war()
+  NV_IF_TARGET(NV_IS_HOST,
+               (return war_nvbugs_881631::host_path(exec, ptr);),
+               (return war_nvbugs_881631::device_path(exec, ptr);))
+} // end get_value_msvc2005_war()
 } // end anon namespace
 
 

--- a/thrust/system/cuda/detail/iter_swap.h
+++ b/thrust/system/cuda/detail/iter_swap.h
@@ -26,6 +26,8 @@
 #include <thrust/system/cuda/detail/execution_policy.h>
 #include <thrust/swap.h>
 
+#include <nv/target>
+
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub {
 
@@ -50,15 +52,12 @@ void iter_swap(thrust::cuda::execution_policy<DerivedPolicy> &, Pointer1 a, Poin
     }
   };
 
-  if (THRUST_IS_HOST_CODE) {
-    #if THRUST_INCLUDE_HOST_CODE
-      war_nvbugs_881631::host_path(a, b);
-    #endif
-  } else {
-    #if THRUST_INCLUDE_DEVICE_CODE
-      war_nvbugs_881631::device_path(a, b);
-    #endif
-  }
+  NV_IF_TARGET(NV_IS_HOST, (
+    war_nvbugs_881631::host_path(a, b);
+  ), (
+    war_nvbugs_881631::device_path(a, b);
+  ));
+
 } // end iter_swap()
 
 

--- a/thrust/system/cuda/detail/par.h
+++ b/thrust/system/cuda/detail/par.h
@@ -48,6 +48,7 @@ private:
   cudaStream_t stream;
 
 public:
+  __thrust_exec_check_disable__
   __host__ __device__
   execute_on_stream_base(cudaStream_t stream_ = default_stream())
       : stream(stream_){}

--- a/thrust/system/cuda/detail/util.h
+++ b/thrust/system/cuda/detail/util.h
@@ -35,9 +35,11 @@
 
 #include <cub/detail/device_synchronize.cuh>
 #include <cub/util_arch.cuh>
+#include <cub/util_device.cuh>
+
+#include <nv/target>
 
 THRUST_NAMESPACE_BEGIN
-
 namespace cuda_cub {
 
 inline __host__ __device__
@@ -94,25 +96,7 @@ __host__ __device__
 cudaError_t
 synchronize_stream(execution_policy<Derived> &policy)
 {
-  cudaError_t result;
-  if (THRUST_IS_HOST_CODE) {
-    #if THRUST_INCLUDE_HOST_CODE
-      cudaStreamSynchronize(stream(policy));
-      result = cudaGetLastError();
-    #endif
-  } else {
-    #if THRUST_INCLUDE_DEVICE_CODE
-      #if __THRUST_HAS_CUDART__
-        THRUST_UNUSED_VAR(policy);
-        cub::detail::device_synchronize();
-        result = cudaGetLastError();
-      #else
-        THRUST_UNUSED_VAR(policy);
-        result = cudaSuccess;
-      #endif
-    #endif
-  }
-  return result;
+  return cub::SyncStream(stream(policy));
 }
 
 // Entry point/interface.
@@ -132,30 +116,16 @@ cudaError_t
 synchronize_stream_optional(execution_policy<Derived> &policy)
 {
   cudaError_t result;
-  if (THRUST_IS_HOST_CODE) {
-    #if THRUST_INCLUDE_HOST_CODE
-      if(must_perform_optional_synchronization(policy)){
-        cudaStreamSynchronize(stream(policy));
-        result = cudaGetLastError();
-      }else{
-        result = cudaSuccess;
-      }
-    #endif
-  } else {
-    #if THRUST_INCLUDE_DEVICE_CODE
-      #if __THRUST_HAS_CUDART__
-        if(must_perform_optional_synchronization(policy)){
-          cub::detail::device_synchronize();
-          result = cudaGetLastError();
-        }else{
-          result = cudaSuccess;
-        }
-      #else
-        THRUST_UNUSED_VAR(policy);
-        result = cudaSuccess;
-      #endif
-    #endif
+
+  if (must_perform_optional_synchronization(policy))
+  {
+    result = synchronize_stream(policy);
   }
+  else
+  {
+    result = cudaSuccess;
+  }
+
   return result;
 }
 
@@ -230,15 +200,7 @@ trivial_copy_device_to_device(Policy &    policy,
 inline void __host__ __device__
 terminate()
 {
-  if (THRUST_IS_DEVICE_CODE) {
-    #if THRUST_INCLUDE_DEVICE_CODE
-      asm("trap;");
-    #endif
-  } else {
-    #if THRUST_INCLUDE_HOST_CODE
-      std::terminate();
-    #endif
-  }
+  NV_IF_TARGET(NV_IS_HOST, (std::terminate();), (asm("trap;");));
 }
 
 __host__  __device__
@@ -252,23 +214,33 @@ inline void throw_on_error(cudaError_t status)
 
   if (cudaSuccess != status)
   {
-    if (THRUST_IS_HOST_CODE) {
-      #if THRUST_INCLUDE_HOST_CODE
-        throw thrust::system_error(status, thrust::cuda_category());
-      #endif
-    } else {
-      #if THRUST_INCLUDE_DEVICE_CODE
-        #if __THRUST_HAS_CUDART__
-          printf("Thrust CUDA backend error: %s: %s\n",
-                 cudaGetErrorName(status),
-                 cudaGetErrorString(status));
-        #else
-          printf("Thrust CUDA backend error: %d\n",
-                 static_cast<int>(status));
-        #endif
-        cuda_cub::terminate();
-      #endif
-    }
+
+    // Can't use #if inside NV_IF_TARGET, use a temp macro to hoist the device
+    // instructions out of the target logic.
+#if __THRUST_HAS_CUDART__
+
+#define THRUST_TEMP_DEVICE_CODE \
+  printf("Thrust CUDA backend error: %s: %s\n", \
+         cudaGetErrorName(status), \
+         cudaGetErrorString(status))
+
+#else
+
+#define THRUST_TEMP_DEVICE_CODE \
+  printf("Thrust CUDA backend error: %d\n", \
+         static_cast<int>(status))
+
+#endif
+
+    NV_IF_TARGET(NV_IS_HOST, (
+      throw thrust::system_error(status, thrust::cuda_category());
+    ), (
+      THRUST_TEMP_DEVICE_CODE;
+      cuda_cub::terminate();
+    ));
+
+#undef THRUST_TEMP_DEVICE_CODE
+
   }
 }
 
@@ -283,25 +255,34 @@ inline void throw_on_error(cudaError_t status, char const *msg)
 
   if (cudaSuccess != status)
   {
-    if (THRUST_IS_HOST_CODE) {
-      #if THRUST_INCLUDE_HOST_CODE
-        throw thrust::system_error(status, thrust::cuda_category(), msg);
-      #endif
-    } else {
-      #if THRUST_INCLUDE_DEVICE_CODE
-        #if __THRUST_HAS_CUDART__
-          printf("Thrust CUDA backend error: %s: %s: %s\n",
-                 cudaGetErrorName(status),
-                 cudaGetErrorString(status),
-                 msg);
-        #else
-          printf("Thrust CUDA backend error: %d: %s \n",
-                 static_cast<int>(status),
-                 msg);
-        #endif
-        cuda_cub::terminate();
-      #endif
-    }
+    // Can't use #if inside NV_IF_TARGET, use a temp macro to hoist the device
+    // instructions out of the target logic.
+#if __THRUST_HAS_CUDART__
+
+#define THRUST_TEMP_DEVICE_CODE \
+  printf("Thrust CUDA backend error: %s: %s: %s\n", \
+         cudaGetErrorName(status), \
+         cudaGetErrorString(status),\
+         msg)
+
+#else
+
+#define THRUST_TEMP_DEVICE_CODE \
+  printf("Thrust CUDA backend error: %d: %s\n", \
+         static_cast<int>(status),              \
+         msg)
+
+#endif
+
+    NV_IF_TARGET(NV_IS_HOST, (
+      throw thrust::system_error(status, thrust::cuda_category(), msg);
+    ), (
+      THRUST_TEMP_DEVICE_CODE;
+      cuda_cub::terminate();
+    ));
+
+#undef THRUST_TEMP_DEVICE_CODE
+
   }
 }
 

--- a/thrust/system/detail/sequential/sort.inl
+++ b/thrust/system/detail/sequential/sort.inl
@@ -24,6 +24,8 @@
 #include <thrust/system/detail/sequential/stable_merge_sort.h>
 #include <thrust/system/detail/sequential/stable_primitive_sort.h>
 
+#include <nv/target>
+
 THRUST_NAMESPACE_BEGIN
 namespace system
 {
@@ -164,14 +166,14 @@ void stable_sort(sequential::execution_policy<DerivedPolicy> &exec,
 {
 
   // the compilation time of stable_primitive_sort is too expensive to use within a single CUDA thread
-#ifndef __CUDA_ARCH__
-  typedef typename thrust::iterator_traits<RandomAccessIterator>::value_type KeyType;
-  sort_detail::use_primitive_sort<KeyType,StrictWeakOrdering> use_primitive_sort;
-#else
-  thrust::detail::false_type use_primitive_sort;
-#endif
-
-  sort_detail::stable_sort(exec, first, last, comp, use_primitive_sort);
+  NV_IF_TARGET(NV_IS_HOST, (
+    using KeyType = thrust::iterator_value_t<RandomAccessIterator>;
+    sort_detail::use_primitive_sort<KeyType, StrictWeakOrdering> use_primitive_sort;
+    sort_detail::stable_sort(exec, first, last, comp, use_primitive_sort);
+  ), ( // NV_IS_DEVICE:
+    thrust::detail::false_type use_primitive_sort;
+    sort_detail::stable_sort(exec, first, last, comp, use_primitive_sort);
+  ));
 }
 
 
@@ -188,14 +190,14 @@ void stable_sort_by_key(sequential::execution_policy<DerivedPolicy> &exec,
 {
 
   // the compilation time of stable_primitive_sort_by_key is too expensive to use within a single CUDA thread
-#ifndef __CUDA_ARCH__
-  typedef typename thrust::iterator_traits<RandomAccessIterator1>::value_type KeyType;
-  sort_detail::use_primitive_sort<KeyType,StrictWeakOrdering> use_primitive_sort;
-#else
-  thrust::detail::false_type use_primitive_sort;
-#endif
-
-  sort_detail::stable_sort_by_key(exec, first1, last1, first2, comp, use_primitive_sort);
+  NV_IF_TARGET(NV_IS_HOST, (
+    using KeyType = thrust::iterator_value_t<RandomAccessIterator1>;
+    sort_detail::use_primitive_sort<KeyType, StrictWeakOrdering> use_primitive_sort;
+    sort_detail::stable_sort_by_key(exec, first1, last1, first2, comp, use_primitive_sort);
+  ), ( // NV_IS_DEVICE:
+    thrust::detail::false_type use_primitive_sort;
+    sort_detail::stable_sort_by_key(exec, first1, last1, first2, comp, use_primitive_sort);
+  ));
 }
 
 

--- a/thrust/system/detail/sequential/stable_merge_sort.inl
+++ b/thrust/system/detail/sequential/stable_merge_sort.inl
@@ -24,6 +24,8 @@
 #include <thrust/system/detail/sequential/insertion_sort.h>
 #include <thrust/detail/minmax.h>
 
+#include <nv/target>
+
 THRUST_NAMESPACE_BEGIN
 namespace system
 {
@@ -355,16 +357,12 @@ void stable_merge_sort(sequential::execution_policy<DerivedPolicy> &exec,
                        RandomAccessIterator last,
                        StrictWeakOrdering comp)
 {
-  if (THRUST_IS_DEVICE_CODE) {
-    #if THRUST_INCLUDE_DEVICE_CODE
-      // avoid recursion in CUDA threads
-      stable_merge_sort_detail::iterative_stable_merge_sort(exec, first, last, comp);
-    #endif
-  } else {
-    #if THRUST_INCLUDE_HOST_CODE
-      stable_merge_sort_detail::recursive_stable_merge_sort(exec, first, last, comp);
-    #endif
-  }
+  NV_IF_TARGET(NV_IS_DEVICE, (
+    // avoid recursion in CUDA threads
+    stable_merge_sort_detail::iterative_stable_merge_sort(exec, first, last, comp);
+  ), (
+    stable_merge_sort_detail::recursive_stable_merge_sort(exec, first, last, comp);
+  ));
 }
 
 
@@ -379,16 +377,12 @@ void stable_merge_sort_by_key(sequential::execution_policy<DerivedPolicy> &exec,
                               RandomAccessIterator2 first2,
                               StrictWeakOrdering comp)
 {
-  if (THRUST_IS_DEVICE_CODE) {
-    #if THRUST_INCLUDE_DEVICE_CODE
-      // avoid recursion in CUDA threads
-      stable_merge_sort_detail::iterative_stable_merge_sort_by_key(exec, first1, last1, first2, comp);
-    #endif
-  } else {
-    #if THRUST_INCLUDE_HOST_CODE
-      stable_merge_sort_detail::recursive_stable_merge_sort_by_key(exec, first1, last1, first2, comp);
-    #endif
-  }
+  NV_IF_TARGET(NV_IS_DEVICE, (
+    // avoid recursion in CUDA threads
+    stable_merge_sort_detail::iterative_stable_merge_sort_by_key(exec, first1, last1, first2, comp);
+  ), (
+    stable_merge_sort_detail::recursive_stable_merge_sort_by_key(exec, first1, last1, first2, comp);
+  ));
 }
 
 

--- a/thrust/system/detail/sequential/trivial_copy.h
+++ b/thrust/system/detail/sequential/trivial_copy.h
@@ -24,6 +24,8 @@
 #include <cstring>
 #include <thrust/system/detail/sequential/general_copy.h>
 
+#include <nv/target>
+
 THRUST_NAMESPACE_BEGIN
 namespace system
 {
@@ -40,16 +42,14 @@ __host__ __device__
                     T *result)
 {
   T* return_value = NULL;
-  if (THRUST_IS_HOST_CODE) {
-    #if THRUST_INCLUDE_HOST_CODE
-      std::memmove(result, first, n * sizeof(T));
-      return_value = result + n;
-    #endif
-  } else {
-    #if THRUST_INCLUDE_DEVICE_CODE
-      return_value = thrust::system::detail::sequential::general_copy_n(first, n, result);
-    #endif
-  }
+
+  NV_IF_TARGET(NV_IS_HOST, (
+    std::memmove(result, first, n * sizeof(T));
+    return_value = result + n;
+  ), ( // NV_IS_DEVICE:
+    return_value = thrust::system::detail::sequential::general_copy_n(first, n, result);
+  ));
+
   return return_value;
 } // end trivial_copy_n()
 


### PR DESCRIPTION
Requires NVIDIA/cub#448.

This PR contains an initial set of changes necessary to migrate Thrust and CUB to NV_IF_TARGET and remove dependence on `__CUDA_ARCH__`. It does not fully remove all usages of `__CUDA_ARCH__`, but rather focuses on the following:

* Establish the libcu++ dependency for both Thrust and CUB.
* Remove obsolete checks for unsupported CUDA architectures.
* Migrate host/device divergent code from `#ifdef __CUDA_ARCH__` to use `NV_IF_TARGET`.

This also includes various bug fixes for issues exposed by the above.

Future PRs will address the remaining usages of `__CUDA_ARCH__` in the CDP macros and the kernel dispatch infrastructure.

# Pre-written Release Notes

## Breaking Changes

- NVIDIA/thrust#1605: Add libcu++ dependency.
- NVIDIA/thrust#1605: The following macros are no longer defined by default. They can be re-enabled by defining `THRUST_PROVIDE_LEGACY_ARCH_MACROS`.  These will be removed completely in a future release.
    - `THRUST_IS_HOST_CODE`: Replace with `NV_IF_TARGET`.
    - `THRUST_IS_DEVICE_CODE`: Replace with `NV_IF_TARGET`.
    - `THRUST_INCLUDE_HOST_CODE`: Replace with `NV_IF_TARGET`.
    - `THRUST_INCLUDE_DEVICE_CODE`: Replace with `NV_IF_TARGET`.
    - `THRUST_DEVICE_CODE`: Replace with `NV_IF_TARGET`.

## Other Enhancements

- NVIDIA/thrust#1605: Removed special case code for unsupported CUDA architectures.
- NVIDIA/thrust#1605: Replace several usages of `__CUDA_ARCH__` with `<nv/target>` to handle host/device code divergence.

## Bug Fixes

- NVIDIA/thrust#1605: Fix some execution space warnings in the allocator library.