### PR TITLE
NaN output fix for pow(complex(0,0), 0)

### DIFF
--- a/thrust/detail/complex/cpow.h
+++ b/thrust/detail/complex/cpow.h
@@ -39,6 +39,9 @@ complex<typename detail::promoted_numerical_type<T0, T1>::type>
 pow(const complex<T0>& x, const T1& y)
 {
   typedef typename detail::promoted_numerical_type<T0, T1>::type T;
+  if (x.imag() == 0.0) {
+    return pow(x.real(), y);
+  }
   return exp(log(complex<T>(x)) * T(y));
 }
 


### PR DESCRIPTION
Current implementation outputs NaN for 0^0.
But many widely used formulas involving real-number exponents require 0^0 to be defined as 1.
https://en.wikipedia.org/wiki/Zero_to_the_power_of_zero