### PR TITLE
Add GDB pretty-printer for thrust vectors and references

### DIFF
--- a/scripts/gdb-pretty-printers.py
+++ b/scripts/gdb-pretty-printers.py
@@ -1,0 +1,119 @@
+import gdb
+import sys
+
+if sys.version_info[0] > 2:
+    Iterator = object
+else:
+    # "Polyfill" for Python2 Iterator interface
+    class Iterator:
+        def next(self):
+            return self.__next__()
+
+
+class ThrustVectorPrinter(gdb.printing.PrettyPrinter):
+    "Print a thrust::*_vector"
+
+    class _host_accessible_iterator(Iterator):
+        def __init__(self, start, size):
+            self.item = start
+            self.size = size
+            self.count = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.count >= self.size:
+                raise StopIteration
+            elt = self.item.dereference()
+            count = self.count
+            self.item = self.item + 1
+            self.count = self.count + 1
+            return ('[%d]' % count, elt)
+
+    class _device_iterator(Iterator):
+        def __init__(self, start, size):
+            self.exec = exec
+            self.item = start
+            self.size = size
+            self.count = 0
+            self.buffer = None
+            self.sizeof = self.item.dereference().type.sizeof
+            self.buffer_start = 0
+            # At most 1 MB or size, at least 1
+            self.buffer_size = min(size, max(1, 2 ** 20 // self.sizeof))
+            self.buffer = gdb.parse_and_eval(
+                '(void*)malloc(%s)' % (self.buffer_size * self.sizeof))
+            self.buffer.fetch_lazy()
+            self.buffer_count = self.buffer_size
+            self.update_buffer()
+
+        def update_buffer(self):
+            if self.buffer_count >= self.buffer_size:
+                self.buffer_item = gdb.parse_and_eval(
+                    hex(self.buffer)).cast(self.item.type)
+                self.buffer_count = 0
+                self.buffer_start = self.count
+                device_addr = hex(self.item.dereference().address)
+                buffer_addr = hex(self.buffer)
+                size = min(self.buffer_size, self.size -
+                           self.buffer_start) * self.sizeof
+                status = gdb.parse_and_eval(
+                    '(cudaError)cudaMemcpy(%s, %s, %d, cudaMemcpyDeviceToHost)' % (buffer_addr, device_addr, size))
+                if status != 0:
+                    raise gdb.MemoryError(
+                        'memcpy from device failed: %s' % status)
+
+        def __del__(self):
+            gdb.parse_and_eval('(void)free(%s)' %
+                               hex(self.buffer)).fetch_lazy()
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.count >= self.size:
+                raise StopIteration
+            self.update_buffer()
+            elt = self.buffer_item.dereference()
+            self.buffer_item = self.buffer_item + 1
+            self.buffer_count = self.buffer_count + 1
+            count = self.count
+            self.item = self.item + 1
+            self.count = self.count + 1
+            return ('[%d]' % count, elt)
+
+    def __init__(self, val):
+        self.val = val
+        self.pointer = val['m_storage']['m_begin']['m_iterator']
+        self.size = int(val['m_size'])
+        self.capacity = int(val['m_storage']['m_size'])
+        self.is_device = False
+        if str(self.pointer.type).startswith("thrust::device_ptr"):
+            self.pointer = self.pointer['m_iterator']
+            self.is_device = True
+
+    def children(self):
+        if self.is_device:
+            return self._device_iterator(self.pointer, self.size)
+        else:
+            return self._host_accessible_iterator(self.pointer, self.size)
+
+    def to_string(self):
+        typename = str(self.val.type)
+        return ('%s of length %d, capacity %d' % (typename, self.size, self.capacity))
+
+    def display_hint(self):
+        return 'array'
+
+
+def lookup_thrust_type(val):
+    if not str(val.type.unqualified()).startswith('thrust::'):
+        return None
+    suffix = str(val.type.unqualified())[8:]
+    if suffix.startswith('host_vector') or suffix.startswith('device_vector'):
+        return ThrustVectorPrinter(val)
+    return None
+
+
+gdb.pretty_printers.append(lookup_thrust_type)


### PR DESCRIPTION
I saw #1318 and really liked the idea of providing pretty-printers even for device-side data, so I implemented it in our own library (https://github.com/ginkgo-project/ginkgo/pull/987), and thought it might be useful here as well :) I removed all non-trivial parts of the code that were copied from libstdc++, so there should be no licensing issues. This is ~~should be~~ straightforward to extend to device references ~~, I only had a few issues with getting the device pointer out from a device_reference (gdb returns a heap pointer for `D[0].ptr.m_iterator`, but what looks like a device pointer for `D.m_storage.m_begin.m_iterator.m_iterator` in `examples/basic_vector.cu`, so there must be something weird going wrong with the temporary `D[0]` I guess?)~~

I can't really speak on the potential for hangs that was discussed in the original issue, aside from "it works for me" - that would be something the runtime folks need to answer.

Example run:

```
(gdb) b 33
Breakpoint 1 at 0xc3e8: file /home/tobi/thrust/examples/basic_vector.cu, line 33.
(gdb) run
Starting program: /home/tobi/thrust/build/bin/thrust.example.basic_vector 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
H has size 4
H[0] = 14
H[1] = 20
H[2] = 38
H[3] = 46
H now has size 2
[New Thread 0x7fffefea3000 (LWP 2198)]

Thread 1 "thrust.example." hit Breakpoint 1, main () at /home/tobi/thrust/examples/basic_vector.cu:33
33          D[0] = 99;
(gdb) source ../scripts/gdb-pretty-printers.py 
(gdb) print H
$1 = thrust::host_vector<int, std::allocator<int> > of length 2, capacity 4 = {14, 20}
(gdb) print D
$2 = thrust::device_vector<int, thrust::device_allocator<int> > of length 2, capacity 2 = {14, 20}
(gdb) print D[1]
$3 = (thrust::device_reference<int>) @0xb047f0004: 20
(gdb)
```

Fixes #1318 