### PR TITLE
Increase contrast of search input text in docs.

### DIFF
--- a/docs/github_pages/_sass/color_schemes/nvidia.scss
+++ b/docs/github_pages/_sass/color_schemes/nvidia.scss
@@ -142,3 +142,4 @@ span.doxybook-comment
 .highlight span.gd { color: #ff0000; } /* Generic.Deleted */
 .highlight span.gi { color: #00ff00; } /* Generic.Inserted */
 
+.search-input { color: $body-text-color; }


### PR DESCRIPTION
See related fix to libcudacxx: https://github.com/NVIDIA/libcudacxx/pull/258

This PR increases the contrast of the documentation's search bar text so that the input text is legible.

If reviewers are aware of other instances of this issue beyond libcudacxx/thrust, let me know and I can make corresponding updates to other repositories.

I verified that this fix works for Firefox, Chrome, and Edge browsers. All three browsers show light text on a dark background in the placeholder text and when input is entered.

Before, without input (Firefox):
![image](https://user-images.githubusercontent.com/3943761/159189157-64f1985c-1537-4fc4-a241-18285f2f5b65.png)

After, without input (Firefox):
![image](https://user-images.githubusercontent.com/3943761/159189171-dbe56095-056a-403f-a7ba-902e20844901.png)

After, with input (Chrome):
![image](https://user-images.githubusercontent.com/3943761/159594964-5b1037b2-cac3-4bb0-bd97-cfff91eebdf8.png)