### PR TITLE
Add __forceinline__ to thrust::detail::wrapped_function::operator()

### DIFF
--- a/thrust/detail/function.h
+++ b/thrust/detail/function.h
@@ -42,7 +42,7 @@ struct wrapped_function
 
   __thrust_exec_check_disable__
   template <typename Argument>
-  inline __host__ __device__
+  __thrust_forceinline__ __host__ __device__
   Result operator()(Argument& x) const
   {
     return static_cast<Result>(m_f(thrust::raw_reference_cast(x)));
@@ -50,7 +50,7 @@ struct wrapped_function
 
   __thrust_exec_check_disable__
   template <typename Argument>
-  inline __host__ __device__
+  __thrust_forceinline__ __host__ __device__
   Result operator()(const Argument& x) const
   {
     return static_cast<Result>(m_f(thrust::raw_reference_cast(x)));
@@ -58,7 +58,7 @@ struct wrapped_function
 
   __thrust_exec_check_disable__
   template <typename Argument1, typename Argument2>
-  inline __host__ __device__
+  __thrust_forceinline__ __host__ __device__
   Result operator()(Argument1& x, Argument2& y) const
   {
     return static_cast<Result>(m_f(thrust::raw_reference_cast(x),
@@ -67,7 +67,7 @@ struct wrapped_function
 
   __thrust_exec_check_disable__
   template <typename Argument1, typename Argument2>
-  inline __host__ __device__
+  __thrust_forceinline__ __host__ __device__
   Result operator()(const Argument1& x, Argument2& y) const
   {
     return static_cast<Result>(m_f(thrust::raw_reference_cast(x),
@@ -76,7 +76,7 @@ struct wrapped_function
 
   __thrust_exec_check_disable__
   template <typename Argument1, typename Argument2>
-  inline __host__ __device__
+  __thrust_forceinline__ __host__ __device__
   Result operator()(const Argument1& x, const Argument2& y) const
   {
     return static_cast<Result>(m_f(thrust::raw_reference_cast(x),
@@ -85,7 +85,7 @@ struct wrapped_function
 
   __thrust_exec_check_disable__
   template <typename Argument1, typename Argument2>
-  inline __host__ __device__
+  __thrust_forceinline__ __host__ __device__
   Result operator()(Argument1& x, const Argument2& y) const
   {
     return static_cast<Result>(m_f(thrust::raw_reference_cast(x),
@@ -111,7 +111,7 @@ struct wrapped_function<Function, void>
 
   __thrust_exec_check_disable__
   template <typename Argument>
-  inline __host__ __device__
+  __thrust_forceinline__ __host__ __device__
   void operator()(Argument& x) const
   {
     m_f(thrust::raw_reference_cast(x));
@@ -119,7 +119,7 @@ struct wrapped_function<Function, void>
 
   __thrust_exec_check_disable__
   template <typename Argument>
-  inline __host__ __device__
+  __thrust_forceinline__ __host__ __device__
   void operator()(const Argument& x) const
   {
     m_f(thrust::raw_reference_cast(x));
@@ -127,7 +127,7 @@ struct wrapped_function<Function, void>
 
   __thrust_exec_check_disable__
   template <typename Argument1, typename Argument2>
-  inline __host__ __device__
+  __thrust_forceinline__ __host__ __device__
   void operator()(Argument1& x, Argument2& y) const
   {
     m_f(thrust::raw_reference_cast(x), thrust::raw_reference_cast(y));
@@ -135,21 +135,21 @@ struct wrapped_function<Function, void>
 
   __thrust_exec_check_disable__
   template <typename Argument1, typename Argument2>
-  inline __host__ __device__
+  __thrust_forceinline__ __host__ __device__
   void operator()(const Argument1& x, Argument2& y) const
   {
     m_f(thrust::raw_reference_cast(x), thrust::raw_reference_cast(y));
   }
   __thrust_exec_check_disable__
   template <typename Argument1, typename Argument2>
-  inline __host__ __device__
+  __thrust_forceinline__ __host__ __device__
   void operator()(const Argument1& x, const Argument2& y) const
   {
     m_f(thrust::raw_reference_cast(x), thrust::raw_reference_cast(y));
   }
   __thrust_exec_check_disable__
   template <typename Argument1, typename Argument2>
-  inline __host__ __device__
+  __thrust_forceinline__ __host__ __device__
   void operator()(Argument1& x, const Argument2& y) const
   {
     m_f(thrust::raw_reference_cast(x), thrust::raw_reference_cast(y));


### PR DESCRIPTION
This pull request adds forced inlining to `thrust::detail::wrapped_function::operator()`. This makes sure that when a function with the `__forceinline__` attribute is wrapped (e.g. when it is passed to `thrust::for_each`), it is actually inlined into the caller (e.g. `thrust::for_each`) and not just inlined into the wrapper, which may or may not have been inlined into the caller automatically.

When a function that does not have the `__forceinline__` attribute is wrapped, this pull request only has a minor effect. Previously the compiler could decide to inline the wrapper into the caller or the function into the wrapper (it would always do one or the other because the wrapper is so simple). Now it can only decide to inline the function into the wrapper or not as the wrapper is always inlined into the caller.