### PR TITLE
partial fix for iterator traits and tags

### DIFF
--- a/testing/regression/CMakeLists.txt
+++ b/testing/regression/CMakeLists.txt
@@ -1,3 +1,7 @@
+if ("thrust" IN_LIST THRUST_TARGETS)
+  thrust_add_test(test_target "regression.gh_902__iterator_category_to_system_returns_wrong_tag" "gh_902__iterator_category_to_system_returns_wrong_tag.cu" "thrust")
+endif()
+
 #
 # Disabled as these test names are too long for CMAKE_OBJECT_PATH_MAX.
 # We should integrate these with the other unit tests.

--- a/testing/regression/gh_902__iterator_category_to_system_returns_wrong_tag.cu
+++ b/testing/regression/gh_902__iterator_category_to_system_returns_wrong_tag.cu
@@ -1,0 +1,22 @@
+#include <thrust/iterator/detail/iterator_category_with_system_and_traversal.h>
+#include <thrust/iterator/iterator_categories.h>
+#include <thrust/iterator/iterator_traits.h>
+
+template <class IteratorCategory>
+using _category_to_system_t =
+    typename thrust::detail::iterator_category_to_system<IteratorCategory>::type;
+
+static_assert(std::is_same<thrust::device_system_tag, _category_to_system_t<thrust::output_device_iterator_tag>>::value);
+static_assert(std::is_same<thrust::device_system_tag, _category_to_system_t<thrust::input_device_iterator_tag>>::value);
+// static_assert(std::is_same<thrust::device_system_tag, _category_to_system_t<thrust::forward_device_iterator_tag>>::value);
+// static_assert(std::is_same<thrust::device_system_tag, _category_to_system_t<thrust::bidirectional_device_iterator_tag>>::value);
+// static_assert(std::is_same<thrust::device_system_tag, _category_to_system_t<thrust::random_access_device_iterator_tag>>::value);
+
+static_assert(std::is_same<thrust::host_system_tag, _category_to_system_t<thrust::output_host_iterator_tag>>::value);
+static_assert(std::is_same<thrust::host_system_tag, _category_to_system_t<thrust::input_host_iterator_tag>>::value);
+static_assert(std::is_same<thrust::host_system_tag, _category_to_system_t<thrust::forward_host_iterator_tag>>::value);
+static_assert(std::is_same<thrust::host_system_tag, _category_to_system_t<thrust::bidirectional_host_iterator_tag>>::value);
+static_assert(std::is_same<thrust::host_system_tag, _category_to_system_t<thrust::random_access_host_iterator_tag>>::value);
+
+// static_assert(!std::is_convertible<thrust::input_device_iterator_tag, thrust::input_host_iterator_tag>::value);
+static_assert(!std::is_convertible<thrust::input_host_iterator_tag, thrust::input_device_iterator_tag>::value);

--- a/thrust/iterator/detail/iterator_category_to_system.h
+++ b/thrust/iterator/detail/iterator_category_to_system.h
@@ -38,24 +38,24 @@ template <typename> struct device_iterator_category_to_backend_system;
 // we should just specialize this metafunction for iterator_category_with_system_and_traversal
 template<typename Category>
   struct iterator_category_to_system
-    // convertible to host iterator?
+    // convertible to device iterator?
     : eval_if<
         or_<
-          is_convertible<Category, thrust::input_host_iterator_tag>,
-          is_convertible<Category, thrust::output_host_iterator_tag>
+          is_convertible<Category, thrust::input_device_iterator_tag>,
+          is_convertible<Category, thrust::output_device_iterator_tag>
         >::value,
 
-        detail::identity_<thrust::host_system_tag>,
-        
-        // convertible to device iterator?
+        detail::identity_<thrust::device_system_tag>,
+
+        // convertible to host iterator?
         eval_if<
           or_<
-            is_convertible<Category, thrust::input_device_iterator_tag>,
-            is_convertible<Category, thrust::output_device_iterator_tag>
+            is_convertible<Category, thrust::input_host_iterator_tag>,
+            is_convertible<Category, thrust::output_host_iterator_tag>
           >::value,
 
-          detail::identity_<thrust::device_system_tag>,
-
+          detail::identity_<thrust::host_system_tag>,
+        
           // unknown system
           detail::identity_<void>
         > // if device

--- a/thrust/iterator/detail/iterator_category_to_traversal.h
+++ b/thrust/iterator/detail/iterator_category_to_traversal.h
@@ -88,23 +88,23 @@ template <typename Category>
 
 template<typename Category>
   struct category_to_traversal
-      // check for host system
+      // check for device system
     : eval_if<
         or_<
-          is_convertible<Category, thrust::input_host_iterator_tag>,
-          is_convertible<Category, thrust::output_host_iterator_tag>
+          is_convertible<Category, thrust::input_device_iterator_tag>,
+          is_convertible<Category, thrust::output_device_iterator_tag>
         >::value,
 
-        host_system_category_to_traversal<Category>,
+        device_system_category_to_traversal<Category>,
 
-        // check for device system
+        // check for host system
         eval_if<
           or_<
-            is_convertible<Category, thrust::input_device_iterator_tag>,
-            is_convertible<Category, thrust::output_device_iterator_tag>
+            is_convertible<Category, thrust::input_host_iterator_tag>,
+            is_convertible<Category, thrust::output_host_iterator_tag>
           >::value,
 
-          device_system_category_to_traversal<Category>,
+          host_system_category_to_traversal<Category>,
 
           // unknown category
           detail::identity_<void>


### PR DESCRIPTION
The symptoms of this problem are described in #902. Really, there are two problems with the way Thrust's iterator tags are currently defined:

1. The `*_device_*` iterator tags are erroneously convertible the `*_host_*` tags. That's because the `*_host_*` tags are simply type aliases for the standard iterator tags, which the `*_device_*` tags inherit from.

2. Because of the way the device iterator tags are defined (with `iterator_category_with_system_and_traversal`) there is no relationship between the different device tags. We would expect (and much of the code does) that `thrust::forward_device_iterator_tag` is convertible to `thrust::input_device_iterator_tag`, but that is sadly not true.

The two traits, `iterator_category_to_system` and `iterator_category_to_traversal`, are first checking whether the category is convertible to a host iterator tag. That is trivially true even for the device tags because of (1); as a result, device tags appear to have the "host" system, which is incorrect.

This PR offers the simplest, least intrusive, and sadly partial fix to the problem reported in #902. It changes the two traits so that they first check for convertibility to the _device_ tag. This gets the answer correctly in more cases than currently.

I _think_ I know how to fix this properly, but not without potentially breaking some code, so I'm submitting this PR now as a stop-gap.