### PR TITLE
Make any_system_tag only convertible to other system tags

### DIFF
--- a/thrust/detail/execution_policy.h
+++ b/thrust/detail/execution_policy.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <thrust/detail/config.h>
+#include <thrust/detail/type_traits.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -65,6 +66,11 @@ const DerivedPolicy &derived_cast(const execution_policy_base<DerivedPolicy> &x)
 {
   return static_cast<const DerivedPolicy&>(x);
 }
+
+template <class>
+struct is_system_tag
+  : false_type
+{};
 
 } // end detail
 

--- a/thrust/iterator/detail/any_system_tag.h
+++ b/thrust/iterator/detail/any_system_tag.h
@@ -18,6 +18,7 @@
 
 #include <thrust/detail/config.h>
 #include <thrust/detail/execution_policy.h>
+#include <thrust/detail/type_traits.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -25,9 +26,20 @@ struct any_system_tag
   : thrust::execution_policy<any_system_tag>
 {
   // allow any_system_tag to convert to any type at all
-  // XXX make this safer using enable_if<is_tag<T>> upon c++11
-  template<typename T> operator T () const {return T();}
+  template<typename T,
+           typename detail::enable_if<detail::is_system_tag<T>::value, int>::type = 0>
+  operator T () const {return T();}
 };
+
+namespace detail {
+
+template <>
+struct is_system_tag<any_system_tag>
+  : true_type
+{};
+
+}
+
 
 THRUST_NAMESPACE_END
 

--- a/thrust/iterator/detail/any_system_tag.h
+++ b/thrust/iterator/detail/any_system_tag.h
@@ -25,7 +25,7 @@ THRUST_NAMESPACE_BEGIN
 struct any_system_tag
   : thrust::execution_policy<any_system_tag>
 {
-  // allow any_system_tag to convert to any type at all
+  // allow any_system_tag to convert to any system tag type
   template<typename T,
            typename detail::enable_if<detail::is_system_tag<T>::value, int>::type = 0>
   operator T () const {return T();}

--- a/thrust/iterator/detail/device_system_tag.h
+++ b/thrust/iterator/detail/device_system_tag.h
@@ -27,4 +27,13 @@ THRUST_NAMESPACE_BEGIN
 
 typedef thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::tag device_system_tag;
 
+namespace detail {
+
+template <>
+struct is_system_tag<device_system_tag>
+  : true_type
+{};
+
+}
+
 THRUST_NAMESPACE_END

--- a/thrust/iterator/detail/host_system_tag.h
+++ b/thrust/iterator/detail/host_system_tag.h
@@ -27,4 +27,13 @@ THRUST_NAMESPACE_BEGIN
 
 typedef thrust::system::__THRUST_HOST_SYSTEM_NAMESPACE::tag host_system_tag;
 
+namespace detail {
+
+template <>
+struct is_system_tag<host_system_tag>
+  : true_type
+{};
+
+}
+
 THRUST_NAMESPACE_END


### PR DESCRIPTION
`any_system_tag` is currently defined as:

```c++
struct any_system_tag
  : thrust::execution_policy<any_system_tag>
{
  // allow any_system_tag to convert to any type at all
  // XXX make this safer using enable_if<is_tag<T>> upon c++11
  template<typename T> operator T () const {return T();}
};
```

We're C++11 now, so we can and should constrain this conversion operator.

This change is relevant to the future work on iterator categories and tag dispatching.