### PR TITLE
Remove `cub` symlink.

### DIFF
--- a/cub
+++ b/cub
@@ -1,1 +1,0 @@
-dependencies/cub/cub


### PR DESCRIPTION
This breaks builds on some toolchains.

Users should explicitly set their include directories for Thrust's dependencies:

```
-I ${THRUST_ROOT}/dependencies/cub
-I ${THRUST_ROOT}/dependencies/libcudacxx/include
```

If using Thrust's CMake packages, these paths will be configured automatically.

Fixes #1328.