### PR TITLE
Missing macro wrapper for zip_function

### DIFF
--- a/thrust/zip_function.h
+++ b/thrust/zip_function.h
@@ -34,6 +34,7 @@ namespace zip_detail {
 // Add workaround for decltype(auto) on C++11-only compilers:
 #if THRUST_CPP_DIALECT >= 2014
 
+__thrust_exec_check_disable__
 template <typename Function, typename Tuple, std::size_t... Is>
 __host__ __device__
 decltype(auto) apply_impl(Function&& func, Tuple&& args, index_sequence<Is...>)
@@ -51,6 +52,7 @@ decltype(auto) apply(Function&& func, Tuple&& args)
 
 #else // THRUST_CPP_DIALECT
 
+__thrust_exec_check_disable__
 template <typename Function, typename Tuple, std::size_t... Is>
 __host__ __device__
 auto apply_impl(Function&& func, Tuple&& args, index_sequence<Is...>)


### PR DESCRIPTION
thrust::make_zip_function didn't work with device c++ lambdas as input, this patch suggested by @jrhemstad adds the macro wrapper `__thrust_exec_check_disable__` macro to fix it.