### PR TITLE
Implement `shift_left` and `shift_right` algorithms

### DIFF
--- a/testing/shift.cu
+++ b/testing/shift.cu
@@ -1,0 +1,253 @@
+#include <unittest/unittest.h>
+#include <thrust/iterator/iterator_traits.h>
+#include <thrust/shift.h>
+
+template<typename Vector>
+void TestShiftLeftSimple(void)
+{
+    typedef typename Vector::value_type T;
+
+    Vector data = {1, 2, 3, 4, 5, 6 }
+
+    typename Vector::iterator end = thrust::shift_left(data.begin(),
+                                                       data.end(),
+                                                       2);
+
+    ASSERT_EQUAL(data.end() - end, 2);
+
+    ASSERT_EQUAL(data[0], 3);
+    ASSERT_EQUAL(data[1], 4);
+    ASSERT_EQUAL(data[2], 5);
+    ASSERT_EQUAL(data[3], 6);
+}
+DECLARE_VECTOR_UNITTEST(TestShiftLeftSimple);
+
+
+template<typename ForwardIterator>
+ForwardIterator shift_left(my_system &system,
+                           ForwardIterator first,
+                           ForwardIterator,
+                           typename thrust::iterator_traits<ForwardIterator>::difference_type)
+{
+    system.validate_dispatch();
+    return first;
+}
+
+void TestShiftLeftDispatchExplicit()
+{
+    thrust::device_vector<int> vec(1);
+
+    my_system sys(0);
+    thrust::shift_left(sys, vec.begin(), vec.end(), 1);
+
+    ASSERT_EQUAL(true, sys.is_valid());
+}
+DECLARE_UNITTEST(TestShiftLeftDispatchExplicit);
+
+
+template<typename ForwardIterator,
+         typename T>
+ForwardIterator shift_left(my_tag,
+                           ForwardIterator first,
+                           ForwardIterator,
+                           typename thrust::iterator_traits<ForwardIterator>::difference_type)
+{
+    *first = 13;
+    return first;
+}
+
+void TestShiftLeftDispatchImplicit()
+{
+    thrust::device_vector<int> vec(1);
+
+    thrust::shift_left(thrust::retag<my_tag>(vec.begin()),
+                       thrust::retag<my_tag>(vec.begin()),
+                       2);
+
+    ASSERT_EQUAL(13, vec.front());
+}
+DECLARE_UNITTEST(TestShiftLeftDispatchImplicit);
+
+
+template<typename Vector>
+void TestShiftRightSimple(void)
+{
+    typedef typename Vector::value_type T;
+
+    Vector data = {1, 2, 3, 4, 5, 6 }
+
+    typename Vector::iterator begin = thrust::shift_right(data.begin(),
+                                                          data.end(),
+                                                          2);
+
+    ASSERT_EQUAL(begin - data.begin(), 2);
+
+    ASSERT_EQUAL(data[2], 1);
+    ASSERT_EQUAL(data[3], 2);
+    ASSERT_EQUAL(data[4], 3);
+    ASSERT_EQUAL(data[5], 4);
+}
+DECLARE_VECTOR_UNITTEST(TestShiftRightSimple);
+
+
+template<typename ForwardIterator>
+ForwardIterator shift_right(my_system &system,
+                            ForwardIterator first,
+                            ForwardIterator,
+                            typename thrust::iterator_traits<ForwardIterator>::difference_type)
+{
+    system.validate_dispatch();
+    return first;
+}
+
+void TestShiftRightDispatchExplicit()
+{
+    thrust::device_vector<int> vec(1);
+
+    my_system sys(0);
+    thrust::shift_right(sys, vec.begin(), vec.end(), 1);
+
+    ASSERT_EQUAL(true, sys.is_valid());
+}
+DECLARE_UNITTEST(TestShiftRightDispatchExplicit);
+
+
+template<typename ForwardIterator,
+         typename T>
+ForwardIterator shift_right(my_tag,
+                            ForwardIterator first,
+                            ForwardIterator,
+                            typename thrust::iterator_traits<ForwardIterator>::difference_type)
+{
+    *first = 13;
+    return first;
+}
+
+void TestShiftRightDispatchImplicit()
+{
+    thrust::device_vector<int> vec(1);
+
+    thrust::shift_right(thrust::retag<my_tag>(vec.begin()),
+                       thrust::retag<my_tag>(vec.begin()),
+                       2);
+
+    ASSERT_EQUAL(13, vec.front());
+}
+DECLARE_UNITTEST(TestShiftRightDispatchImplicit);
+
+
+template<typename T>
+void TestShiftLeft(const size_t n)
+{
+    thrust::host_vector<T>   h_data = unittest::random_samples<T>(n);
+    thrust::device_vector<T> d_data = h_data;
+
+    size_t h_size = thrust::shift_left(h_data.begin(), h_data.end(), 2) - h_data.begin();
+    size_t d_size = thrust::shift_left(d_data.begin(), d_data.end(), 2) - d_data.begin();
+
+    ASSERT_EQUAL(h_size, d_size);
+
+    h_data.resize(h_size);
+    d_data.resize(d_size);
+
+    ASSERT_EQUAL(h_data, d_data);
+}
+DECLARE_VARIABLE_UNITTEST(TestShiftLeft);
+
+
+template<typename T>
+void TestShiftRight(const size_t n)
+{
+    thrust::host_vector<T>   h_data = unittest::random_samples<T>(n);
+    thrust::device_vector<T> d_data = h_data;
+
+    auto h_res = thrust::shift_right(h_data.begin(), h_data.end(), 2);
+    auto d_res = thrust::shift_right(d_data.begin(), d_data.end(), 2);
+
+    size_t h_size = h_res - h_data.begin();
+    size_t d_size = d_res - d_data.begin();
+
+    ASSERT_EQUAL(h_size, d_size);
+
+    h_data.remove(h_data.begin(), h_res);
+    d_data.remove(d_data.begin(), d_res);
+
+    ASSERT_EQUAL(h_data, d_data);
+}
+DECLARE_VARIABLE_UNITTEST(TestShiftRight);
+
+
+template<typename T>
+void TestShiftLeftBoundaries(const size_t n)
+{
+    thrust::host_vector<T>   h_data = unittest::random_samples<T>(n);
+    thrust::host_vector<T>   reference = h_data;
+    thrust::device_vector<T> d_data = h_data;
+
+    auto h_res_zero_shift = thrust::shift_left(h_data.begin(), h_data.end(), 0);
+    auto d_res_zero_shift = thrust::shift_left(d_data.begin(), d_data.end(), 0);
+    ASSERT_EQUAL(h_res_zero_shift, h_data.end());
+    ASSERT_EQUAL(d_res_zero_shift, d_data.end());
+    ASSERT_EQUAL(h_data, reference);
+    ASSERT_EQUAL(d_data, reference);
+
+    auto h_res_negative_shift = thrust::shift_left(h_data.begin(), h_data.end(), -5);
+    auto d_res_negative_shift = thrust::shift_left(d_data.begin(), d_data.end(), -5);
+    ASSERT_EQUAL(h_res_zero_shift, h_data.end());
+    ASSERT_EQUAL(d_res_zero_shift, d_data.end());
+    ASSERT_EQUAL(h_data, reference);
+    ASSERT_EQUAL(d_data, reference);
+
+    auto h_res_full_shift = thrust::shift_left(h_data.begin(), h_data.end(), n);
+    auto d_res_full_shift = thrust::shift_left(d_data.begin(), d_data.end(), n);
+    ASSERT_EQUAL(h_res_zero_shift, h_data.begin());
+    ASSERT_EQUAL(d_res_zero_shift, d_data.begin());
+    ASSERT_EQUAL(h_data, reference);
+    ASSERT_EQUAL(d_data, reference);
+
+    auto h_res_beyond_range_shift = thrust::shift_left(h_data.begin(), h_data.end(), n + 2);
+    auto d_res_beyond_range_shift = thrust::shift_left(d_data.begin(), d_data.end(), n + 2);
+    ASSERT_EQUAL(h_res_zero_shift, h_data.begin());
+    ASSERT_EQUAL(d_res_zero_shift, d_data.begin());
+    ASSERT_EQUAL(h_data, reference);
+    ASSERT_EQUAL(d_data, reference);
+}
+DECLARE_VARIABLE_UNITTEST(TestShiftLeftBoundaries);
+
+
+template<typename T>
+void TestShiftRightBoundaries(const size_t n)
+{
+    thrust::host_vector<T>   h_data = unittest::random_samples<T>(n);
+    thrust::host_vector<T>   reference = h_data;
+    thrust::device_vector<T> d_data = h_data;
+
+    auto h_res_zero_shift = thrust::shift_right(h_data.begin(), h_data.end(), 0);
+    auto d_res_zero_shift = thrust::shift_right(d_data.begin(), d_data.end(), 0);
+    ASSERT_EQUAL(h_res_zero_shift, h_data.begin());
+    ASSERT_EQUAL(d_res_zero_shift, d_data.begin());
+    ASSERT_EQUAL(h_data, reference);
+    ASSERT_EQUAL(d_data, reference);
+
+    auto h_res_negative_shift = thrust::shift_right(h_data.begin(), h_data.end(), -5);
+    auto d_res_negative_shift = thrust::shift_right(d_data.begin(), d_data.end(), -5);
+    ASSERT_EQUAL(h_res_negative_shift, h_data.begin());
+    ASSERT_EQUAL(d_res_negative_shift, d_data.begin());
+    ASSERT_EQUAL(h_data, reference);
+    ASSERT_EQUAL(d_data, reference);
+
+    auto h_res_full_shift = thrust::shift_right(h_data.begin(), h_data.end(), n);
+    auto d_res_full_shift = thrust::shift_right(d_data.begin(), d_data.end(), n);
+    ASSERT_EQUAL(h_res_full_shift, h_data.end());
+    ASSERT_EQUAL(d_res_full_shift, d_data.end());
+    ASSERT_EQUAL(h_data, reference);
+    ASSERT_EQUAL(d_data, reference);
+
+    auto h_res_beyond_range_shift = thrust::shift_right(h_data.begin(), h_data.end(), n + 2);
+    auto d_res_beyond_range_shift = thrust::shift_right(d_data.begin(), d_data.end(), n + 2);
+    ASSERT_EQUAL(h_res_beyond_range_shift, h_data.end());
+    ASSERT_EQUAL(d_res_beyond_range_shift, d_data.end());
+    ASSERT_EQUAL(h_data, reference);
+    ASSERT_EQUAL(d_data, reference);
+}
+DECLARE_VARIABLE_UNITTEST(TestShiftRightBoundaries);

--- a/thrust/detail/shift.inl
+++ b/thrust/detail/shift.inl
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2022 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+#include <thrust/shift.h>
+#include <thrust/iterator/iterator_traits.h>
+#include <thrust/system/detail/generic/select_system.h>
+#include <thrust/system/detail/generic/shift.h>
+#include <thrust/system/detail/adl/shift.h>
+
+THRUST_NAMESPACE_BEGIN
+
+__thrust_exec_check_disable__
+template<typename DerivedPolicy, typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_left(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+               ForwardIterator first,
+               ForwardIterator last,
+               typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  using thrust::system::detail::generic::shift_left;
+  return shift_left(thrust::detail::derived_cast(thrust::detail::strip_const(exec)), first, last, n);
+} // end shift_left()
+
+
+__thrust_exec_check_disable__
+template<typename DerivedPolicy, typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_right(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+               ForwardIterator first,
+               ForwardIterator last,
+               typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  using thrust::system::detail::generic::shift_left;
+  return shift_right(thrust::detail::derived_cast(thrust::detail::strip_const(exec)), first, last, n);
+} // end shift_right()
+
+
+template<typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_left(ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  using thrust::system::detail::generic::select_system;
+
+  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+
+  System system;
+
+  return thrust::shift_left(select_system(system), first, last, n);
+} // end shift_left()
+
+
+template<typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_right(ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  using thrust::system::detail::generic::select_system;
+
+  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+
+  System system;
+
+  return thrust::shift_right(select_system(system), first, last, n);
+} // end shift_right()
+
+THRUST_NAMESPACE_END

--- a/thrust/shift.h
+++ b/thrust/shift.h
@@ -1,0 +1,221 @@
+/*
+ *  Copyright 2022 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a shift_left of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+/*! \file thrust/shift.h
+ *  \brief Shifts the elements of a range to the front / end
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+#include <thrust/detail/execution_policy.h>
+#include <thrust/iterator/iterator_traits.h>
+
+THRUST_NAMESPACE_BEGIN
+
+/*! \addtogroup algorithms
+ */
+
+/*! \addtogroup stream_compaction
+ *  \{
+ */
+
+
+/*! \p shift_left shifts the elements from the range [\p first, \p last) to the left. That is, it performs
+ *  the assignments *\p first = *(\p first + \p n), *(\p first + \c 1) = *(\p first + \p n + \c 1),
+ *  and so on. Generally, for every integer \c m from \c 0 to \p last - \p first - n, \p shift_left
+ *  performs the assignment *(\p first + \c m) = *(\p first + \c m + \p n). Unlike \c std::shift_left,
+ *  \p shift_left offers no guarantee on order of operation. Elements that are in the original range but
+ *  not the new range are left in a valid but unspecified state. If \p n is equal to zero or greater than
+ *  (\p last - \p first) the algorithm has no effect.
+ *
+ *  The return value is the end of the resulting range \p first + (\p last - \p first - \p n).
+ *
+ *  The algorithm's execution is parallelized as determined by \p exec.
+ *
+ *  \param exec The execution policy to use for parallelization.
+ *  \param first The beginning of the sequence to shift.
+ *  \param last The end of the sequence to shift.
+ *  \param n The number of positions to shift.
+ *  \return The end of the resulting sequence.
+ *  \see https://en.cppreference.com/w/cpp/algorithm/shift
+ *
+ *  \tparam DerivedPolicy The name of the derived execution policy.
+ *  \tparam ForwardIterator must be a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward Iterator</a>.
+ *
+ *  \pre \p n may be equal to equal to zero or greater than (\p last - \p first), but \p n shall not be negative
+ *
+ *
+ *  The following code snippet demonstrates how to use \p shift_left
+ *  on a range using the \p thrust::device parallelization policy:
+ *
+ *  \code
+ *  #include <thrust/shift.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *  ...
+ *
+ *  thrust::device_vector<int> vec = {1, 2, 3, 4, 5, 6};
+ *  ...
+ *
+ *  thrust::shift_left(thrust::device, vec.begin(), vec.end(), 2);
+ *
+ *  // vec is now equal to {3, 4, 5, 6, unspecified, unspecified }
+ *  \endcode
+ */
+template <typename DerivedPolicy, typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_left(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n);
+
+
+/*! \p shift_left shifts the elements from the range [\p first, \p last) to the left. That is, it performs
+ *  the assignments *\p first = *(\p first + \p n), *(\p first + \c 1) = *(\p first + \p n + \c 1),
+ *  and so on. Generally, for every integer \c m from \c 0 to \p last - \p first - n, \p shift_left
+ *  performs the assignment *(\p first + \c m) = *(\p first + \c m + \p n). Elements that are in the
+ *  original range but not the new range are left in a valid but unspecified state. If \p n is equal
+ *  to zero or greater than (\p last - \p first) the algorithm has no effect.
+ *
+ *  The return value is the end of the resulting range \p first + (\p last - \p first - \p n).
+ *
+ *  \param first The beginning of the sequence to shift.
+ *  \param last The end of the sequence to shift.
+ *  \param n The number of positions to shift.
+ *  \return The end of the resulting sequence.
+ *  \see https://en.cppreference.com/w/cpp/algorithm/shift
+ *
+ *  \tparam ForwardIterator must be a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward Iterator</a>.
+ *
+ *  \pre \p n may be equal to equal to zero or greater than (\p last - \p first), but \p n shall not be negative
+ *
+ *  The following code snippet demonstrates how to use \p shift_left on a range:
+ *
+ *  \code
+ *  #include <thrust/shift.h>
+ *  #include <thrust/device_vector.h>
+ *  ...
+ *
+ *  thrust::device_vector<int> vec = {1, 2, 3, 4, 5, 6};
+ *  ...
+ *
+ *  thrust::shift_left(vec.begin(), vec.end(), 2);
+ *
+ *  // vec is now equal to {3, 4, 5, 6, unspecified, unspecified }
+ *  \endcode
+ */
+template <typename ForwardIterator>
+  ForwardIterator shift_left(ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n);
+
+
+/*! \p shift_right shifts the elements from the range [\p first, \p last) to the right. That is, it performs
+ *  the assignments *(\p first + \p n) = *\p first, *(\p first + \p n + \c 1) = *(\p first + \c 1),
+ *  and so on. Generally, for every integer \c m from \c 0 to \p last - \p first - n, \p shift_right
+ *  performs the assignment *(\p first + \c m + \p n) = *(\p first + \c m). Unlike \c std::shift_right,
+ *  \p shift_right offers no guarantee on order of operation. Elements that are in the original range but
+ *  not the new range are left in a valid but unspecified state. If \p n is equal to zero or greater than
+ *  (\p last - \p first) the algorithm has no effect.
+ *
+ *  The return value is the beginning of the resulting range \p first + \p n.
+ *
+ *  The algorithm's execution is parallelized as determined by \p exec.
+ *
+ *  \param exec The execution policy to use for parallelization.
+ *  \param first The beginning of the sequence to shift.
+ *  \param last The end of the sequence to shift.
+ *  \param n The number of positions to shift.
+ *  \return The beginning of the resulting sequence.
+ *  \see https://en.cppreference.com/w/cpp/algorithm/shift
+ *
+ *  \tparam DerivedPolicy The name of the derived execution policy.
+ *  \tparam ForwardIterator must be a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward Iterator</a>.
+ *
+ *  \pre \p n may be equal to equal to zero or greater than (\p last - \p first), but \p n shall not be negative
+ *
+ *  The following code snippet demonstrates how to use \p shift_right on the elements of a range
+ *  using the \p thrust::device parallelization policy:
+ *
+ *  \code
+ *  #include <thrust/shift.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *  ...
+ *
+ *  thrust::device_vector<int> vec = {1, 2, 3, 4, 5, 6};
+ *  ...
+ *
+ *  thrust::shift_right(thrust::device, vec.begin(), vec.end(), 2);
+ *
+ *  // vec is now equal to {unspecified, unspecified, 1, 2, 3, 4 }
+ *  \endcode
+ */
+template <typename DerivedPolicy, typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_right(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+                      ForwardIterator first,
+                      ForwardIterator last,
+                      typename thrust::iterator_traits<ForwardIterator>::difference_type n);
+
+
+/*! \p shift_right shifts the elements from the range [\p first, \p last) to the right. That is, it performs
+ *  the assignments *(\p first + \p n) = *\p first, *(\p first + \p n + \c 1) = *(\p first + \c 1),
+ *  and so on. Generally, for every integer \c m from \c 0 to \p last - \p first - n, \p shift_right
+ *  performs the assignment *(\p first + \c m + \p n) = *(\p first + \c m). Elements that are in the original
+ *  range but not the new range are left in a valid but unspecified state. If \p n is equal to zero or greater
+ *  than (\p last - \p first) the algorithm has no effect.
+ *
+ *  The return value is the beginning of the resulting range \p first + \p n.
+ *
+ *  \param first The beginning of the sequence to shift.
+ *  \param last The end of the sequence to shift.
+ *  \param n The number of positions to shift.
+ *  \return The beginning of the resulting sequence.
+ *  \see https://en.cppreference.com/w/cpp/algorithm/shift
+ *
+ *  \tparam ForwardIterator must be a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward Iterator</a>.
+ *
+ *  \pre \p n may be equal to equal to zero or greater than (\p last - \p first), but \p n shall not be negative
+ *
+ *  The following code snippet demonstrates how to use \p shift_right on the elements of a range:
+ *
+ *  \code
+ *  #include <thrust/shift.h>
+ *  #include <thrust/device_vector.h>
+ *  ...
+ *
+ *  thrust::device_vector<int> vec = {1, 2, 3, 4, 5, 6};
+ *  ...
+ *
+ *  thrust::shift_right(vec.begin(), vec.end(), 2);
+ *
+ *  // vec is now equal to {unspecified, unspecified, 1, 2, 3, 4 }
+ *  \endcode
+ */
+template <typename ForwardIterator>
+  ForwardIterator shift_right(ForwardIterator first,
+                              ForwardIterator last,
+                              typename thrust::iterator_traits<ForwardIterator>::difference_type n);
+
+/*! \} // end stream_compaction
+ */
+
+THRUST_NAMESPACE_END
+
+#include <thrust/detail/shift.inl>

--- a/thrust/system/cpp/detail/shift.h
+++ b/thrust/system/cpp/detail/shift.h
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2022 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+// this system inherits shift
+#include <thrust/system/detail/sequential/shift.h>
+

--- a/thrust/system/cuda/detail/shift.h
+++ b/thrust/system/cuda/detail/shift.h
@@ -1,0 +1,95 @@
+/******************************************************************************
+ * Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_NVCC
+#include <thrust/system/cuda/detail/copy.h>
+#include <thrust/detail/temporary_array.h>
+
+THRUST_NAMESPACE_BEGIN
+
+namespace cuda_cub {
+
+
+template<typename Derived,
+         typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_left(execution_policy<Derived> &policy,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  if (n <= 0) {
+    return last;
+  }
+
+  const auto len = thrust::distance(first, last);
+  if (n >= len) {
+    return first;
+  }
+
+  ForwardIterator new_first = first;
+  thrust::advance(new_first, n)
+
+  thrust::detail::temporary_array<thrust::value_t<ForwardIterator>, Derived> tmp{policy, new_first, last};
+  return cuda_cub::copy(policy, tmp.begin(), tmp.end(), first);
+}
+
+template<typename Derived,
+         typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_right(execution_policy<Derived> &policy,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  if (n <= 0) {
+    return first;
+  }
+
+  const auto len = thrust::distance(first, last);
+  if (n >= len) {
+    return last;
+  }
+
+  ForwardIterator new_last = first;
+  thrust::advance(new_last, len - n)
+
+  thrust::detail::temporary_array<thrust::value_t<ForwardIterator>, Derived> tmp{policy, first, new_last};
+
+  thrust::advance(first, n)
+  cuda_cub::copy(policy, tmp.begin(), tmp.end(), first);
+
+  return first;
+}
+
+} // namespace cuda_cub
+
+THRUST_NAMESPACE_END
+#endif

--- a/thrust/system/detail/adl/shift.h
+++ b/thrust/system/detail/adl/shift.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2022 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a fill of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+// the purpose of this header is to #include the shift.h header
+// of the sequential, host, and device systems. It should be #included in any
+// code which uses adl to dispatch sequence
+
+#include <thrust/system/detail/sequential/shift.h>
+
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/shift.h>
+#include <thrust/system/cuda/detail/shift.h>
+#include <thrust/system/omp/detail/shift.h>
+#include <thrust/system/tbb/detail/shift.h>
+#endif
+
+#define __THRUST_HOST_SYSTEM_SHIFT_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/shift.h>
+#include __THRUST_HOST_SYSTEM_SHIFT_HEADER
+#undef __THRUST_HOST_SYSTEM_SHIFT_HEADER
+
+#define __THRUST_DEVICE_SYSTEM_SHIFT_HEADER <__THRUST_DEVICE_SYSTEM_ROOT/detail/shift.h>
+#include __THRUST_DEVICE_SYSTEM_SHIFT_HEADER
+#undef __THRUST_DEVICE_SYSTEM_SHIFT_HEADER
+

--- a/thrust/system/detail/generic/shift.h
+++ b/thrust/system/detail/generic/shift.h
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2022 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+#include <thrust/system/detail/generic/tag.h>
+#include <thrust/iterator/iterator_traits.h>
+
+THRUST_NAMESPACE_BEGIN
+namespace system
+{
+namespace detail
+{
+namespace generic
+{
+
+
+template <typename DerivedPolicy, typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_left(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n);
+
+
+template <typename DerivedPolicy, typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_right(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n);
+
+} // end generic
+} // end detail
+} // end system
+THRUST_NAMESPACE_END
+
+#include <thrust/system/detail/generic/shift.inl>
+

--- a/thrust/system/detail/generic/shift.inl
+++ b/thrust/system/detail/generic/shift.inl
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2022 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+#include <thrust/detail/temporary_array.h>
+#include <thrust/system/detail/generic/shift.h>
+#include <thrust/iterator/iterator_traits.h>
+#include <thrust/shift.h>
+#include <thrust/copy.h>
+
+THRUST_NAMESPACE_BEGIN
+namespace system
+{
+namespace detail
+{
+namespace generic
+{
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_left(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  if (n <= 0) {
+    return last;
+  }
+
+  const auto len = thrust::distance(first, last);
+  if (n >= len) {
+    return first;
+  }
+
+  ForwardIterator new_first = first;
+  thrust::advance(new_first, n)
+
+  // copy partial input to temp buffer
+  typedef typename thrust::iterator_traits<ForwardIterator>::value_type InputType;
+  thrust::detail::temporary_array<InputType, DerivedPolicy> temp(exec, new_first, last);
+
+  // copy all back to input
+  return thrust::copy(exec, temp.begin(), temp.end(), first);
+} // end shift_left()
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_right(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  if (n <= 0) {
+    return first;
+  }
+
+  const auto len = thrust::distance(first, last);
+  if (n >= len) {
+    return last;
+  }
+
+  ForwardIterator new_last = first;
+  thrust::advance(new_last, len - n)
+
+  // copy full input to temp buffer
+  typedef typename thrust::iterator_traits<ForwardIterator>::value_type InputType;
+  thrust::detail::temporary_array<InputType, DerivedPolicy> temp(exec, first, new_last);
+
+  // copy partially back to input
+  thrust::advance(first, n)
+  thrust::copy(exec, temp.begin(), temp.end(), first);
+  return first;
+} // end shift_right()
+
+} // end generic
+} // end detail
+} // end system
+THRUST_NAMESPACE_END

--- a/thrust/system/detail/sequential/shift.h
+++ b/thrust/system/detail/sequential/shift.h
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2022 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*! \file shift.h
+ *  \brief Sequential implementations of shift algorithms.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+#include <thrust/system/detail/sequential/execution_policy.h>
+#include <thrust/iterator/iterator_traits.h>
+
+THRUST_NAMESPACE_BEGIN
+namespace system
+{
+namespace detail
+{
+namespace sequential
+{
+
+
+template <typename DerivedPolicy, typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_left(sequential::execution_policy<DerivedPolicy> &,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n);
+
+
+template <typename DerivedPolicy, typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_right(sequential::execution_policy<DerivedPolicy> &,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n);
+
+} // end namespace sequential
+} // end namespace detail
+} // end namespace system
+THRUST_NAMESPACE_END
+
+#include <thrust/system/detail/sequential/shift.inl>

--- a/thrust/system/detail/sequential/shift.inl
+++ b/thrust/system/detail/sequential/shift.inl
@@ -1,0 +1,109 @@
+/*
+ *  Copyright 2022 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+#include <thrust/system/detail/sequential/execution_policy.h>
+#include <thrust/iterator/iterator_traits.h>
+#include <thrust/copy.h>
+#include <thrust/swap_ranges.h>
+
+THRUST_NAMESPACE_BEGIN
+namespace system
+{
+namespace detail
+{
+namespace sequential
+{
+
+
+template <typename DerivedPolicy, typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_left(sequential::execution_policy<DerivedPolicy> &,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  if (n <= 0) {
+    return last;
+  }
+
+  ForwardIterator current = first;
+  while (n-- != 0) {
+    if (current == last) {
+      return first;
+    }
+    ++current;
+  }
+
+  while (current != last) {
+    *first = *current;
+  }
+
+  return first;
+}
+
+
+template <typename DerivedPolicy, typename ForwardIterator>
+__host__ __device__
+  ForwardIterator shift_right(sequential::execution_policy<DerivedPolicy> &,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  if (n <= 0) {
+    return first;
+  }
+
+  ForwardIterator current = first;
+  for (auto i = n; i != 0; --i, ++current) {
+    if (current == last) {
+      return last;
+    }
+  }
+
+  // First check whether we can just move parts of [first, current) into
+  // [current, last) and be done with it
+  ForwardIterator trail = first;
+  ForwardIterator lead  = current;
+  for (; trail != current; ++trail, ++lead) {
+    if (lead == last) {
+      thrust::copy(first, trail, current);
+      return current;
+    }
+  }
+
+  // [first, current) and [trail, lead) are now equal sized subranges of [first, last)
+  // swap [first, current) and [trail, lead) until we reach the end
+  while (true) {
+    trail = thrust::swap_ranges(first, current, trail);
+
+    // check whether we reached end
+    ForwardIterator mid = first;
+    for (auto i = n; i != 0; --i, ++lead, ++mid) {
+      if (lead == last) {
+        thrust::copy(first, mid, trail);
+        return current;
+      }
+    }
+  }
+}
+
+} // end namespace sequential
+} // end namespace detail
+} // end namespace system
+THRUST_NAMESPACE_END

--- a/thrust/system/omp/detail/shift.h
+++ b/thrust/system/omp/detail/shift.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright 2022 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+#include <thrust/system/omp/detail/execution_policy.h>
+#include <thrust/iterator/iterator_traits.h>
+
+THRUST_NAMESPACE_BEGIN
+namespace system
+{
+namespace omp
+{
+namespace detail
+{
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_left(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n);
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_right(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n);
+
+
+} // end namespace detail
+} // end namespace omp
+} // end namespace system
+THRUST_NAMESPACE_END
+
+#include <thrust/system/omp/detail/shift.inl>
+

--- a/thrust/system/omp/detail/shift.inl
+++ b/thrust/system/omp/detail/shift.inl
@@ -1,0 +1,118 @@
+/*
+ *  Copyright 2022 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+#include <thrust/system/omp/detail/shift.h>
+#include <thrust/system/detail/generic/shift.h>
+#include <thrust/system/detail/sequential/shift.h>
+#include <thrust/iterator/iterator_traits.h>
+
+
+THRUST_NAMESPACE_BEGIN
+namespace system
+{
+namespace omp
+{
+namespace detail
+{
+namespace dispatch
+{
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_left(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n,
+                    thrust::incrementable_traversal_tag)
+{
+  return thrust::system::detail::sequential::shift_left(exec, first, last, n);
+} // end shift_left()
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_left(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n,
+                    thrust::random_access_traversal_tag)
+{
+  return thrust::system::detail::generic::shift_left(exec, first, last, n);
+} // end shift_left()
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_right(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n,
+                    thrust::incrementable_traversal_tag)
+{
+  return thrust::system::detail::sequential::shift_right(exec, first, last, n);
+} // end shift_right()
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_right(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n,
+                    thrust::random_access_traversal_tag)
+{
+  return thrust::system::detail::generic::shift_right(exec, first, last, n);
+} // end shift_right()
+
+
+} // end dispatch
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_left(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  typedef typename thrust::iterator_traversal<ForwardIterator>::type traversal;
+
+  return thrust::system::omp::detail::dispatch::shift_left(exec, first, last, n, traversal());
+} // end shift_left()
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_right(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  typedef typename thrust::iterator_traversal<ForwardIterator>::type traversal;
+
+  return thrust::system::omp::detail::dispatch::shift_right(exec, first, last, n, traversal());
+} // end shift_right()
+
+
+} // end namespace detail
+} // end namespace omp
+} // end namespace system
+THRUST_NAMESPACE_END
+

--- a/thrust/system/tbb/detail/shift.h
+++ b/thrust/system/tbb/detail/shift.h
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2022 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+#include <thrust/system/tbb/detail/execution_policy.h>
+
+THRUST_NAMESPACE_BEGIN
+namespace system
+{
+namespace tbb
+{
+namespace detail
+{
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_left(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n);
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_right(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n);
+
+
+} // end namespace detail
+} // end namespace tbb
+} // end namespace system
+THRUST_NAMESPACE_END
+
+#include <thrust/system/tbb/detail/shift.inl>
+

--- a/thrust/system/tbb/detail/shift.inl
+++ b/thrust/system/tbb/detail/shift.inl
@@ -1,0 +1,117 @@
+/*
+ *  Copyright 2022 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+#include <thrust/system/tbb/detail/shift.h>
+#include <thrust/system/detail/generic/shift.h>
+#include <thrust/system/detail/sequential/shift.h>
+#include <thrust/iterator/iterator_traits.h>
+
+THRUST_NAMESPACE_BEGIN
+namespace system
+{
+namespace tbb
+{
+namespace detail
+{
+namespace dispatch
+{
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_left(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n,
+                    thrust::incrementable_traversal_tag)
+{
+  return thrust::system::detail::sequential::shift_left(exec, first, last, n);
+} // end shift_left()
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_left(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n,
+                    thrust::random_access_traversal_tag)
+{
+  return thrust::system::detail::generic::shift_left(exec, first, last, n);
+} // end shift_left()
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_right(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n,
+                    thrust::incrementable_traversal_tag)
+{
+  return thrust::system::detail::sequential::shift_right(exec, first, last, n);
+} // end shift_right()
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_right(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n,
+                    thrust::random_access_traversal_tag)
+{
+  return thrust::system::detail::generic::shift_right(exec, first, last, n);
+} // end shift_right()
+
+
+} // end dispatch
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_left(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  typedef typename thrust::iterator_traversal<ForwardIterator>::type traversal;
+
+  return thrust::system::tbb::detail::dispatch::shift_left(exec, first, last, n, traversal());
+} // end shift_left()
+
+
+template<typename DerivedPolicy,
+         typename ForwardIterator>
+ForwardIterator shift_right(execution_policy<DerivedPolicy> &exec,
+                    ForwardIterator first,
+                    ForwardIterator last,
+                    typename thrust::iterator_traits<ForwardIterator>::difference_type n)
+{
+  typedef typename thrust::iterator_traversal<ForwardIterator>::type traversal;
+
+  return thrust::system::tbb::detail::dispatch::shift_right(exec, first, last, n, traversal());
+} // end shift_right()
+
+
+} // end namespace detail
+} // end namespace tbb
+} // end namespace system
+THRUST_NAMESPACE_END
+


### PR DESCRIPTION
This adds both flavors of the new C++20 shift algorithms.

Fixes #1484

NOTE: my stone aged desktop does not have a cuda capable device and it might explode if I try to compile thrust with it, so this is totally eyeballed