### PR TITLE
Remove usage of find_path to locate thrust/version.h

### DIFF
--- a/thrust/cmake/thrust-header-search.cmake
+++ b/thrust/cmake/thrust-header-search.cmake
@@ -1,8 +1,7 @@
-# Parse version information from version.h:
-unset(_THRUST_VERSION_INCLUDE_DIR CACHE) # Clear old result to force search
-find_path(_THRUST_VERSION_INCLUDE_DIR thrust/version.h
-  NO_DEFAULT_PATH # Only search explicit paths below:
-  PATHS
-    "${CMAKE_CURRENT_LIST_DIR}/../.."            # Source tree
-)
-set_property(CACHE _THRUST_VERSION_INCLUDE_DIR PROPERTY TYPE INTERNAL)
+# Parse version information from version.h in source tree
+ # Source tree
+set(_THRUST_VERSION_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
+if(EXISTS "${_THRUST_VERSION_INCLUDE_DIR}/thrust/version.h")
+  set(_THRUST_VERSION_INCLUDE_DIR "${_THRUST_VERSION_INCLUDE_DIR}" CACHE FILEPATH "" FORCE) # Clear old result
+  set_property(CACHE _THRUST_VERSION_INCLUDE_DIR PROPERTY TYPE INTERNAL)
+endif()

--- a/thrust/cmake/thrust-header-search.cmake
+++ b/thrust/cmake/thrust-header-search.cmake
@@ -1,5 +1,4 @@
 # Parse version information from version.h in source tree
- # Source tree
 set(_THRUST_VERSION_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 if(EXISTS "${_THRUST_VERSION_INCLUDE_DIR}/thrust/version.h")
   set(_THRUST_VERSION_INCLUDE_DIR "${_THRUST_VERSION_INCLUDE_DIR}" CACHE FILEPATH "" FORCE) # Clear old result


### PR DESCRIPTION
When a consumer of Thrust uses the CMake `FIND_ROOT_PATH_MODE_INCLUDE` option it will cause all find_path searches to only occur under the find root path. Since this normally doesn't include the source files, it means that thrust-header-search.cmake will fail to find the thrust/version.h file.

This issue was found when using conda-build on a project that includes Thrust, since conda-build sets up a cross compilation
enviornment including a find root path.