### PR TITLE
Fix RDC flags on nvc++ builds.

### DIFF
--- a/cmake/ThrustUtilities.cmake
+++ b/cmake/ThrustUtilities.cmake
@@ -11,15 +11,22 @@ function(thrust_wrap_cu_in_cpp cpp_file_var cu_file thrust_target)
   set(${cpp_file_var} "${cpp_file}" PARENT_SCOPE)
 endfunction()
 
-# Enable RDC for a CUDA target. Encapsulates compiler hacks:
-function(thrust_enable_rdc_for_cuda_target target_name)
+# Enable or disable RDC for a CUDA target.
+# Just using the CMake property won't work for our nvcxx builds, we need
+# to manually specify flags.
+# nvcc disables RDC by default, while nvc++ enables it. Thus this function
+# must be called on all CUDA targets to get consistent RDC state across all
+# platforms.
+function(thrust_set_rdc_state target_name enable)
   if ("NVCXX" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
-    set_target_properties(${target_name} PROPERTIES
-      COMPILE_FLAGS "-gpu=rdc"
-    )
+    if (enable)
+      target_compile_options(${target_name} PRIVATE "-gpu=rdc")
+    else()
+      target_compile_options(${target_name} PRIVATE "-gpu=nordc")
+    endif()
   else()
     set_target_properties(${target_name} PROPERTIES
-      CUDA_SEPARABLE_COMPILATION ON
+      CUDA_SEPARABLE_COMPILATION ${enable}
     )
   endif()
 endfunction()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -105,9 +105,8 @@ function(thrust_add_example target_name_var example_name example_src thrust_targ
   endif()
   add_dependencies(${example_meta_target} ${example_target})
 
-  if ("CUDA" STREQUAL "${config_device}" AND
-      THRUST_ENABLE_EXAMPLES_WITH_RDC)
-    thrust_enable_rdc_for_cuda_target(${example_target})
+  if ("CUDA" STREQUAL "${config_device}")
+    thrust_set_rdc_state(${example_target} ${THRUST_ENABLE_EXAMPLES_WITH_RDC})
   endif()
 
   # Get the name of FileCheck input by stripping out the config name.

--- a/internal/benchmark/CMakeLists.txt
+++ b/internal/benchmark/CMakeLists.txt
@@ -24,6 +24,10 @@ foreach(thrust_target IN LISTS THRUST_TARGETS)
   target_include_directories(${bench_target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
   thrust_clone_target_properties(${bench_target} ${thrust_target})
 
+  if ("CUDA" STREQUAL "${config_device}")
+    thrust_set_rdc_state(${bench_target} OFF)
+  endif()
+
   add_dependencies(thrust.all.bench ${bench_target})
   add_dependencies(${config_prefix}.all ${bench_target})
 endforeach()

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -144,8 +144,8 @@ foreach(thrust_target IN LISTS THRUST_TARGETS)
 
     thrust_add_test(test_target ${test_name} "${test_src}" ${thrust_target})
 
-    if (THRUST_ENABLE_TESTS_WITH_RDC AND ("CUDA" STREQUAL "${config_device}"))
-      thrust_enable_rdc_for_cuda_target(${test_target})
+    if ("CUDA" STREQUAL "${config_device}")
+      thrust_set_rdc_state(${test_target} ${THRUST_ENABLE_TESTS_WITH_RDC})
     endif()
   endforeach()
 endforeach()

--- a/testing/async/CMakeLists.txt
+++ b/testing/async/CMakeLists.txt
@@ -51,9 +51,7 @@ function(thrust_add_async_test_dir algo_name)
       string(PREPEND test_name async.${algo_name}.)
 
       thrust_add_test(test_target ${test_name} "${test_src}" ${thrust_target})
-      if(THRUST_ENABLE_TESTS_WITH_RDC)
-        thrust_enable_rdc_for_cuda_target(${test_target})
-      endif()
+      thrust_set_rdc_state(${test_target} ${THRUST_ENABLE_TESTS_WITH_RDC})
 
       add_dependencies(${algo_config_meta_target} ${test_target})
     endforeach()

--- a/testing/cuda/CMakeLists.txt
+++ b/testing/cuda/CMakeLists.txt
@@ -26,7 +26,8 @@ foreach(thrust_target IN LISTS THRUST_TARGETS)
     # both device-side behaviors -- the CDP kernel launch with RDC, and the
     # serial fallback path without RDC.
     thrust_add_test(seq_test_target ${test_name}.cdp_0 "${test_src}" ${thrust_target})
+    thrust_set_rdc_state(${seq_test_target} OFF)
     thrust_add_test(cdp_test_target ${test_name}.cdp_1 "${test_src}" ${thrust_target})
-    thrust_enable_rdc_for_cuda_target(${cdp_test_target})
+    thrust_set_rdc_state(${cdp_test_target} ON)
   endforeach()
 endforeach()

--- a/testing/unittest/CMakeLists.txt
+++ b/testing/unittest/CMakeLists.txt
@@ -18,4 +18,8 @@ foreach(thrust_target IN LISTS THRUST_TARGETS)
   target_link_libraries(${framework_target} PUBLIC ${thrust_target})
   target_include_directories(${framework_target} PRIVATE "${Thrust_SOURCE_DIR}/testing")
   thrust_clone_target_properties(${framework_target} ${thrust_target})
+
+  if ("CUDA" STREQUAL "${config_device}")
+    thrust_set_rdc_state(${framework_target} OFF)
+  endif()
 endforeach()


### PR DESCRIPTION
nvcc defaults to rdc-off, nvc++ defaults to rdc-on. We need to explicitly
enable or disable these flags for each CUDA target, rather than just
enabling them when needed.