### PR TITLE
copy_if doesn't require copy assignment operator for OutputIterator

### DIFF
--- a/thrust/system/cuda/detail/cdp_dispatch.h
+++ b/thrust/system/cuda/detail/cdp_dispatch.h
@@ -46,7 +46,7 @@
 
 // seq_impl unused.
 #define THRUST_CDP_DISPATCH(par_impl, seq_impl)                                \
-  NV_IF_TARGET(NV_ANY_TARGET, par_impl)
+  NV_IF_TARGET(NV_ANY_TARGET, par_impl, par_impl)
 
 #else // THRUST_RDC_ENABLED
 

--- a/thrust/system/cuda/detail/copy_if.h
+++ b/thrust/system/cuda/detail/copy_if.h
@@ -786,13 +786,13 @@ copy_if(execution_policy<Derived> &policy,
         OutputIterator             result,
         Predicate                  pred)
 {
-  THRUST_CDP_DISPATCH((result = __copy_if::copy_if(policy,
+  THRUST_CDP_DISPATCH((return __copy_if::copy_if(policy,
                                                    first,
                                                    last,
                                                    __copy_if::no_stencil_tag(),
                                                    result,
                                                    pred);),
-                      (result =
+                      (return
                          thrust::copy_if(cvt_to_seq(derived_cast(policy)),
                                          first,
                                          last,
@@ -816,8 +816,8 @@ copy_if(execution_policy<Derived> &policy,
         Predicate                  pred)
 {
   THRUST_CDP_DISPATCH(
-    (result = __copy_if::copy_if(policy, first, last, stencil, result, pred);),
-    (result = thrust::copy_if(cvt_to_seq(derived_cast(policy)),
+    (return __copy_if::copy_if(policy, first, last, stencil, result, pred);),
+    (return thrust::copy_if(cvt_to_seq(derived_cast(policy)),
                               first,
                               last,
                               stencil,

--- a/thrust/system/cuda/detail/copy_if.h
+++ b/thrust/system/cuda/detail/copy_if.h
@@ -798,7 +798,6 @@ copy_if(execution_policy<Derived> &policy,
                                          last,
                                          result,
                                          pred);));
-  return result;
 } // func copy_if
 
 __thrust_exec_check_disable__
@@ -823,7 +822,6 @@ copy_if(execution_policy<Derived> &policy,
                               stencil,
                               result,
                               pred);));
-  return result;
 }    // func copy_if
 
 }    // namespace cuda_cub


### PR DESCRIPTION
For OutputIterators who don't have copy assignment operator, the assignment into result was giving a compiler error. This change avoids using the copy assignment operator.