### PR TITLE
Fix libcu++ usage

### DIFF
--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -716,9 +716,9 @@ template<typename T>
 template <typename Invokable, typename... Args>
 using invoke_result_t =
 #if THRUST_CPP_DIALECT < 2017
-  typename cuda::std::result_of<Invokable(Args...)>::type;
+  typename ::cuda::std::result_of<Invokable(Args...)>::type;
 #else // 2017+
-  cuda::std::invoke_result_t<Invokable, Args...>;
+  ::cuda::std::invoke_result_t<Invokable, Args...>;
 #endif
 
 template <class F, class... Us> 

--- a/thrust/detail/type_traits/result_of_adaptable_function.h
+++ b/thrust/detail/type_traits/result_of_adaptable_function.h
@@ -35,7 +35,7 @@ struct result_of_adaptable_function
 private:
   template <typename Sig> struct impl;
 
-  template <typename F, typename...Args>
+  template <typename F, typename... Args>
   struct impl<F(Args...)>
   {
     using type = invoke_result_t<F, Args...>;


### PR DESCRIPTION
I've used `cuda::std` in the recent additions to thrust. This namespace conflicts with thrust cuda namespace in some cases. This PR changes `cuda::std` namespace to `::cuda::std` one. 