### PR TITLE
Build docs from new commits to main.

### DIFF
--- a/.github/workflows/deploy-documentation-github-pages.yml
+++ b/.github/workflows/deploy-documentation-github-pages.yml
@@ -3,7 +3,10 @@ name: Deploy Documentation GitHub Pages
 on:
   push:
     branches:
-      - feature/new-docs
+      - "main"
+
+  # Trigger on request.
+  workflow_dispatch:
 
 jobs:
   deploy-documentation-github-pages:
@@ -11,7 +14,7 @@ jobs:
     container: gpuci/cccl:cuda11.5.1-devel-ubuntu20.04-gcc9
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Generate documentation markdown
         run: ./docs/generate_markdown.bash --clean
       - name: Deploy generated documentation markdown to gh-pages branch


### PR DESCRIPTION
The thrust docs have fallen out of date because the GitHub Action that builds them is targeting the wrong branch. This PR fixes that so that the docs are built from `main` on every commit. I also added a manual trigger that will appear as a button on the following page: https://github.com/NVIDIA/thrust/actions/workflows/deploy-documentation-github-pages.yml