### PR TITLE
Fix building against libc++ on Windows

### DIFF
--- a/thrust/type_traits/is_contiguous_iterator.h
+++ b/thrust/type_traits/is_contiguous_iterator.h
@@ -156,7 +156,7 @@ struct is_libstdcxx_normal_iterator<
 #if   _MSC_VER >= 1916 // MSVC 2017 version 15.9.
 template <typename Iterator>
 struct is_msvc_contiguous_iterator
-  : is_pointer<::std::_Unwrapped_t<Iterator> > {};
+  : is_pointer<::std::remove_cvref_t<Iterator> > {};
 #elif _MSC_VER >= 1700 // MSVC 2012.
 template <typename Iterator>
 struct is_msvc_contiguous_iterator : false_type {};


### PR DESCRIPTION
In microsoft/stl `std::_Unwrapped_t` [is just](https://github.com/microsoft/STL/blob/2a1b881e2fae9c42026040a7fdfc5a93e59a91c8/stl/inc/xutility#L935) `std::remove_cvref_t`.