### PR TITLE
Various CMake fixes for new build features

### DIFF
--- a/cmake/ThrustBuildCompilerTargets.cmake
+++ b/cmake/ThrustBuildCompilerTargets.cmake
@@ -6,11 +6,9 @@
 # - Interface target providing compiler-specific options needed to build
 #   Thrust's tests, examples, etc.
 #
-# thrust.compiler_interface_cpp11
-# thrust.compiler_interface_cpp14
-# thrust.compiler_interface_cpp17
+# thrust.compiler_interface_cppXX
 # - Interface targets providing compiler-specific options that should only be
-#   applied to certain dialects of C++.
+#   applied to certain dialects of C++. May not be defined for all dialects.
 #
 # thrust.promote_cudafe_warnings
 # - Interface target that adds warning promotion for NVCC cudafe invocations.
@@ -175,7 +173,6 @@ function(thrust_build_compiler_targets)
   # These targets are used for dialect-specific options:
   add_library(thrust.compiler_interface_cpp11 INTERFACE)
   add_library(thrust.compiler_interface_cpp14 INTERFACE)
-  add_library(thrust.compiler_interface_cpp17 INTERFACE)
 
   if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # C4127: conditional expression is constant

--- a/cmake/ThrustBuildTargetList.cmake
+++ b/cmake/ThrustBuildTargetList.cmake
@@ -163,8 +163,14 @@ function(_thrust_add_target_to_target_list target_name host device dialect prefi
 
   target_link_libraries(${target_name} INTERFACE
     thrust.compiler_interface
-    thrust.compiler_interface_cpp${dialect}
   )
+
+  # dialect-specific interface:
+  if (TARGET thrust.compiler_interface_cpp${dialect})
+    target_link_libraries(${target_name} INTERFACE
+      thrust.compiler_interface_cpp${dialect}
+    )
+  endif()
 
   # Workaround Github issue #1174. cudafe promote TBB header warnings to
   # errors, even when they're -isystem includes.

--- a/thrust/cmake/FindTBB.cmake
+++ b/thrust/cmake/FindTBB.cmake
@@ -236,11 +236,12 @@ if (WIN32 AND MSVC)
     set(COMPILER_PREFIX "vc11")
   elseif(MSVC_VERSION EQUAL 1800)
     set(COMPILER_PREFIX "vc12")
-  elseif(MSVC_VERSION GREATER_EQUAL 1900 AND MSVC_VERSION LESS_EQUAL 1929)
+  elseif(MSVC_VERSION GREATER_EQUAL 1900 AND MSVC_VERSION LESS_EQUAL 1939)
       # 1900-1925 actually spans three Visual Studio versions:
       # 1900      = VS 14.0 (v140 toolset) a.k.a. MSVC 2015
       # 1910-1919 = VS 15.0 (v141 toolset) a.k.a. MSVC 2017
       # 1920-1929 = VS 16.0 (v142 toolset) a.k.a. MSVC 2019
+      # 1930-1939 = VS 17.0 (v143 toolset) a.k.a. MSVC 2022
       #
       # But these are binary compatible and TBB's open source distribution only
       # ships a single vs14 lib (as of 2020.0)


### PR DESCRIPTION
Backport of #1780 to `2.0.X`.