### PR TITLE
Remove remnants of `throw()`

### DIFF
--- a/thrust/system/detail/bad_alloc.h
+++ b/thrust/system/detail/bad_alloc.h
@@ -43,7 +43,7 @@ class bad_alloc
 
     inline virtual ~bad_alloc(void) throw () {};
 
-    inline virtual const char *what(void) const throw()
+    inline virtual const char *what(void) const noexcept
     {
       return m_what.c_str();
     } // end what()

--- a/thrust/system/detail/system_error.inl
+++ b/thrust/system/detail/system_error.inl
@@ -76,14 +76,14 @@ system_error
 
 
 const error_code &system_error
-  ::code(void) const throw()
+  ::code(void) const noexcept
 {
   return m_error_code;
 } // end system_error::code()
 
 
 const char *system_error
-  ::what(void) const throw()
+  ::what(void) const noexcept
 {
   if(m_what.empty())
   {

--- a/thrust/system/system_error.h
+++ b/thrust/system/system_error.h
@@ -146,13 +146,13 @@ class system_error
      *  \return <tt>ec</tt> or <tt>error_code(ev, ecat)</tt>, from the
      *          constructor, as appropriate.
      */
-    inline const error_code &code(void) const throw();
+    inline const error_code &code(void) const noexcept;
 
     /*! Returns a human-readable string indicating the nature of the error.
      *  \return a string incorporating <tt>code().message()</tt> and the
      *          arguments supplied in the constructor.
      */
-    inline const char *what(void) const throw();
+    inline const char *what(void) const noexcept;
 
     /*! \cond
      */


### PR DESCRIPTION
the `throw()` specification has been removed with C++20 and will error out on us.

So rather than that, simply use noexcept, as C++03 is thankfully a thing of the past

Fixes nvbug3799847