### PR TITLE
Add transform_output_iterator and transform_input_output_iterator default constructors

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -41,6 +41,10 @@ thrust_declare_test_restrictions(future            CPP.CUDA OMP.CUDA TBB.CUDA)
 # for CUDA.
 thrust_declare_test_restrictions(unittest_static_assert CPP.CPP CPP.CUDA)
 
+# In the TBB backend, reduce_by_key does not currently work with transform_output_iterator
+# https://github.com/NVIDIA/thrust/issues/1811
+thrust_declare_test_restrictions(transform_output_iterator_reduce_by_key CPP.CPP CPP.OMP CPP.CUDA)
+
 ## thrust_add_test
 #
 # Add a test executable and register it with ctest.

--- a/testing/transform_output_iterator.cu
+++ b/testing/transform_output_iterator.cu
@@ -90,3 +90,4 @@ struct TestTransformOutputIteratorScan
     }
 };
 VariableUnitTest<TestTransformOutputIteratorScan, SignedIntegralTypes> TestTransformOutputIteratorScanInstance;
+

--- a/testing/transform_output_iterator.cu
+++ b/testing/transform_output_iterator.cu
@@ -1,133 +1,91 @@
-#include <thrust/copy.h>
-#include <thrust/device_vector.h>
-#include <thrust/functional.h>
-#include <thrust/host_vector.h>
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
-#include <thrust/iterator/transform_output_iterator.h>
-#include <thrust/reduce.h>
-#include <thrust/sequence.h>
-#include <thrust/sort.h>
-
-#include <unittest/random.h>
 #include <unittest/unittest.h>
+#include <thrust/iterator/transform_output_iterator.h>
+
+#include <thrust/copy.h>
+#include <thrust/reduce.h>
+#include <thrust/functional.h>
+#include <thrust/sequence.h>
+#include <thrust/iterator/counting_iterator.h>
 
 template <class Vector>
 void TestTransformOutputIterator(void)
 {
-  typedef typename Vector::value_type T;
+    typedef typename Vector::value_type T;
 
-  typedef thrust::square<T> UnaryFunction;
-  typedef typename Vector::iterator Iterator;
+    typedef thrust::square<T> UnaryFunction;
+    typedef typename Vector::iterator Iterator;
 
-  Vector input(4);
-  Vector output(4);
+    Vector input(4);
+    Vector output(4);
+    
+    // initialize input
+    thrust::sequence(input.begin(), input.end(), T{1});
+   
+    // construct transform_iterator
+    thrust::transform_output_iterator<UnaryFunction, Iterator> output_iter(output.begin(), UnaryFunction());
 
-  // initialize input
-  thrust::sequence(input.begin(), input.end(), T{1});
+    thrust::copy(input.begin(), input.end(), output_iter);
 
-  // construct transform_iterator
-  thrust::transform_output_iterator<UnaryFunction, Iterator> output_iter(output.begin(),
-                                                                         UnaryFunction());
+    Vector gold_output(4);
+    gold_output[0] = 1;
+    gold_output[1] = 4;
+    gold_output[2] = 9;
+    gold_output[3] = 16;
 
-  thrust::copy(input.begin(), input.end(), output_iter);
+    ASSERT_EQUAL(output, gold_output);
 
-  Vector gold_output(4);
-  gold_output[0] = 1;
-  gold_output[1] = 4;
-  gold_output[2] = 9;
-  gold_output[3] = 16;
-
-  ASSERT_EQUAL(output, gold_output);
 }
 DECLARE_VECTOR_UNITTEST(TestTransformOutputIterator);
 
 template <class Vector>
 void TestMakeTransformOutputIterator(void)
 {
-  typedef typename Vector::value_type T;
+    typedef typename Vector::value_type T;
 
-  typedef thrust::square<T> UnaryFunction;
+    typedef thrust::square<T> UnaryFunction;
 
-  Vector input(4);
-  Vector output(4);
+    Vector input(4);
+    Vector output(4);
+    
+    // initialize input
+    thrust::sequence(input.begin(), input.end(), 1);
+   
+    thrust::copy(input.begin(), input.end(),
+                 thrust::make_transform_output_iterator(output.begin(), UnaryFunction()));
 
-  // initialize input
-  thrust::sequence(input.begin(), input.end(), 1);
+    Vector gold_output(4);
+    gold_output[0] = 1;
+    gold_output[1] = 4;
+    gold_output[2] = 9;
+    gold_output[3] = 16;
+    ASSERT_EQUAL(output, gold_output);
 
-  thrust::copy(input.begin(),
-               input.end(),
-               thrust::make_transform_output_iterator(output.begin(), UnaryFunction()));
-
-  Vector gold_output(4);
-  gold_output[0] = 1;
-  gold_output[1] = 4;
-  gold_output[2] = 9;
-  gold_output[3] = 16;
-  ASSERT_EQUAL(output, gold_output);
 }
 DECLARE_VECTOR_UNITTEST(TestMakeTransformOutputIterator);
 
 template <typename T>
 struct TestTransformOutputIteratorScan
 {
-  void operator()(const size_t n)
-  {
-    thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
-    thrust::device_vector<T> d_data = h_data;
+    void operator()(const size_t n)
+    {
+        thrust::host_vector<T>   h_data = unittest::random_samples<T>(n);
+        thrust::device_vector<T> d_data = h_data;
 
-    thrust::host_vector<T> h_result(n);
-    thrust::device_vector<T> d_result(n);
+        thrust::host_vector<T>   h_result(n);
+        thrust::device_vector<T> d_result(n);
 
-    // run on host
-    thrust::inclusive_scan(thrust::make_transform_iterator(h_data.begin(), thrust::negate<T>()),
-                           thrust::make_transform_iterator(h_data.end(), thrust::negate<T>()),
-                           h_result.begin());
-    // run on device
-    thrust::inclusive_scan(d_data.begin(),
-                           d_data.end(),
-                           thrust::make_transform_output_iterator(d_result.begin(),
-                                                                  thrust::negate<T>()));
+        // run on host
+        thrust::inclusive_scan(thrust::make_transform_iterator(h_data.begin(), thrust::negate<T>()),
+                               thrust::make_transform_iterator(h_data.end(),   thrust::negate<T>()),
+                               h_result.begin());
+        // run on device
+        thrust::inclusive_scan(d_data.begin(), d_data.end(),
+                               thrust::make_transform_output_iterator(
+                                   d_result.begin(), thrust::negate<T>()));
 
-    ASSERT_EQUAL(h_result, d_result);
-  }
+
+        ASSERT_EQUAL(h_result, d_result);
+    }
 };
-VariableUnitTest<TestTransformOutputIteratorScan, SignedIntegralTypes>
-  TestTransformOutputIteratorScanInstance;
+VariableUnitTest<TestTransformOutputIteratorScan, SignedIntegralTypes> TestTransformOutputIteratorScanInstance;
 
-template <typename T>
-struct TestTransformOutputIteratorReduceByKey
-{
-  void operator()(const size_t n)
-  {
-    thrust::host_vector<T> h_keys = unittest::random_samples<T>(n);
-    thrust::sort(h_keys.begin(), h_keys.end());
-    thrust::device_vector<T> d_keys = h_keys;
-
-    thrust::host_vector<T> h_values   = unittest::random_samples<T>(n);
-    thrust::device_vector<T> d_values = h_values;
-
-    thrust::host_vector<T> h_result(n);
-    thrust::device_vector<T> d_result(n);
-
-    // run on host
-    thrust::reduce_by_key(thrust::host,
-                          h_keys.begin(),
-                          h_keys.end(),
-                          thrust::make_transform_iterator(h_values.begin(), thrust::negate<T>()),
-                          thrust::discard_iterator<T>{},
-                          h_result.begin());
-    // run on device
-    thrust::reduce_by_key(thrust::device,
-                          d_keys.begin(),
-                          d_keys.end(),
-                          d_values.begin(),
-                          thrust::discard_iterator<T>{},
-                          thrust::make_transform_output_iterator(d_result.begin(),
-                                                                 thrust::negate<T>()));
-
-    ASSERT_EQUAL(h_result, d_result);
-  }
-};
-VariableUnitTest<TestTransformOutputIteratorReduceByKey, SignedIntegralTypes>
-  TestTransformOutputIteratorReduceByKeyInstance;

--- a/testing/transform_output_iterator.cu
+++ b/testing/transform_output_iterator.cu
@@ -1,91 +1,133 @@
-#include <unittest/unittest.h>
-#include <thrust/iterator/transform_output_iterator.h>
-
 #include <thrust/copy.h>
-#include <thrust/reduce.h>
+#include <thrust/device_vector.h>
 #include <thrust/functional.h>
-#include <thrust/sequence.h>
+#include <thrust/host_vector.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/transform_output_iterator.h>
+#include <thrust/reduce.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+#include <unittest/random.h>
+#include <unittest/unittest.h>
 
 template <class Vector>
 void TestTransformOutputIterator(void)
 {
-    typedef typename Vector::value_type T;
+  typedef typename Vector::value_type T;
 
-    typedef thrust::square<T> UnaryFunction;
-    typedef typename Vector::iterator Iterator;
+  typedef thrust::square<T> UnaryFunction;
+  typedef typename Vector::iterator Iterator;
 
-    Vector input(4);
-    Vector output(4);
-    
-    // initialize input
-    thrust::sequence(input.begin(), input.end(), T{1});
-   
-    // construct transform_iterator
-    thrust::transform_output_iterator<UnaryFunction, Iterator> output_iter(output.begin(), UnaryFunction());
+  Vector input(4);
+  Vector output(4);
 
-    thrust::copy(input.begin(), input.end(), output_iter);
+  // initialize input
+  thrust::sequence(input.begin(), input.end(), T{1});
 
-    Vector gold_output(4);
-    gold_output[0] = 1;
-    gold_output[1] = 4;
-    gold_output[2] = 9;
-    gold_output[3] = 16;
+  // construct transform_iterator
+  thrust::transform_output_iterator<UnaryFunction, Iterator> output_iter(output.begin(),
+                                                                         UnaryFunction());
 
-    ASSERT_EQUAL(output, gold_output);
+  thrust::copy(input.begin(), input.end(), output_iter);
 
+  Vector gold_output(4);
+  gold_output[0] = 1;
+  gold_output[1] = 4;
+  gold_output[2] = 9;
+  gold_output[3] = 16;
+
+  ASSERT_EQUAL(output, gold_output);
 }
 DECLARE_VECTOR_UNITTEST(TestTransformOutputIterator);
 
 template <class Vector>
 void TestMakeTransformOutputIterator(void)
 {
-    typedef typename Vector::value_type T;
+  typedef typename Vector::value_type T;
 
-    typedef thrust::square<T> UnaryFunction;
+  typedef thrust::square<T> UnaryFunction;
 
-    Vector input(4);
-    Vector output(4);
-    
-    // initialize input
-    thrust::sequence(input.begin(), input.end(), 1);
-   
-    thrust::copy(input.begin(), input.end(),
-                 thrust::make_transform_output_iterator(output.begin(), UnaryFunction()));
+  Vector input(4);
+  Vector output(4);
 
-    Vector gold_output(4);
-    gold_output[0] = 1;
-    gold_output[1] = 4;
-    gold_output[2] = 9;
-    gold_output[3] = 16;
-    ASSERT_EQUAL(output, gold_output);
+  // initialize input
+  thrust::sequence(input.begin(), input.end(), 1);
 
+  thrust::copy(input.begin(),
+               input.end(),
+               thrust::make_transform_output_iterator(output.begin(), UnaryFunction()));
+
+  Vector gold_output(4);
+  gold_output[0] = 1;
+  gold_output[1] = 4;
+  gold_output[2] = 9;
+  gold_output[3] = 16;
+  ASSERT_EQUAL(output, gold_output);
 }
 DECLARE_VECTOR_UNITTEST(TestMakeTransformOutputIterator);
 
 template <typename T>
 struct TestTransformOutputIteratorScan
 {
-    void operator()(const size_t n)
-    {
-        thrust::host_vector<T>   h_data = unittest::random_samples<T>(n);
-        thrust::device_vector<T> d_data = h_data;
+  void operator()(const size_t n)
+  {
+    thrust::host_vector<T> h_data   = unittest::random_samples<T>(n);
+    thrust::device_vector<T> d_data = h_data;
 
-        thrust::host_vector<T>   h_result(n);
-        thrust::device_vector<T> d_result(n);
+    thrust::host_vector<T> h_result(n);
+    thrust::device_vector<T> d_result(n);
 
-        // run on host
-        thrust::inclusive_scan(thrust::make_transform_iterator(h_data.begin(), thrust::negate<T>()),
-                               thrust::make_transform_iterator(h_data.end(),   thrust::negate<T>()),
-                               h_result.begin());
-        // run on device
-        thrust::inclusive_scan(d_data.begin(), d_data.end(),
-                               thrust::make_transform_output_iterator(
-                                   d_result.begin(), thrust::negate<T>()));
+    // run on host
+    thrust::inclusive_scan(thrust::make_transform_iterator(h_data.begin(), thrust::negate<T>()),
+                           thrust::make_transform_iterator(h_data.end(), thrust::negate<T>()),
+                           h_result.begin());
+    // run on device
+    thrust::inclusive_scan(d_data.begin(),
+                           d_data.end(),
+                           thrust::make_transform_output_iterator(d_result.begin(),
+                                                                  thrust::negate<T>()));
 
-
-        ASSERT_EQUAL(h_result, d_result);
-    }
+    ASSERT_EQUAL(h_result, d_result);
+  }
 };
-VariableUnitTest<TestTransformOutputIteratorScan, SignedIntegralTypes> TestTransformOutputIteratorScanInstance;
+VariableUnitTest<TestTransformOutputIteratorScan, SignedIntegralTypes>
+  TestTransformOutputIteratorScanInstance;
 
+template <typename T>
+struct TestTransformOutputIteratorReduceByKey
+{
+  void operator()(const size_t n)
+  {
+    thrust::host_vector<T> h_keys = unittest::random_samples<T>(n);
+    thrust::sort(h_keys.begin(), h_keys.end());
+    thrust::device_vector<T> d_keys = h_keys;
+
+    thrust::host_vector<T> h_values   = unittest::random_samples<T>(n);
+    thrust::device_vector<T> d_values = h_values;
+
+    thrust::host_vector<T> h_result(n);
+    thrust::device_vector<T> d_result(n);
+
+    // run on host
+    thrust::reduce_by_key(thrust::host,
+                          h_keys.begin(),
+                          h_keys.end(),
+                          thrust::make_transform_iterator(h_values.begin(), thrust::negate<T>()),
+                          thrust::discard_iterator<T>{},
+                          h_result.begin());
+    // run on device
+    thrust::reduce_by_key(thrust::device,
+                          d_keys.begin(),
+                          d_keys.end(),
+                          d_values.begin(),
+                          thrust::discard_iterator<T>{},
+                          thrust::make_transform_output_iterator(d_result.begin(),
+                                                                 thrust::negate<T>()));
+
+    ASSERT_EQUAL(h_result, d_result);
+  }
+};
+VariableUnitTest<TestTransformOutputIteratorReduceByKey, SignedIntegralTypes>
+  TestTransformOutputIteratorReduceByKeyInstance;

--- a/testing/transform_output_iterator.cu
+++ b/testing/transform_output_iterator.cu
@@ -89,3 +89,39 @@ struct TestTransformOutputIteratorScan
 };
 VariableUnitTest<TestTransformOutputIteratorScan, SignedIntegralTypes> TestTransformOutputIteratorScanInstance;
 
+template <typename T>
+struct TestTransformOutputIteratorReduceByKey
+{
+  void operator()(const size_t n)
+  {
+    thrust::host_vector<T> h_keys = unittest::random_samples<T>(n);
+    thrust::sort(h_keys.begin(), h_keys.end());
+    thrust::device_vector<T> d_keys = h_keys;
+
+    thrust::host_vector<T> h_values   = unittest::random_samples<T>(n);
+    thrust::device_vector<T> d_values = h_values;
+
+    thrust::host_vector<T> h_result(n);
+    thrust::device_vector<T> d_result(n);
+
+    // run on host
+    thrust::reduce_by_key(thrust::host,
+                          h_keys.begin(),
+                          h_keys.end(),
+                          thrust::make_transform_iterator(h_values.begin(), thrust::negate<T>()),
+                          thrust::discard_iterator<T>{},
+                          h_result.begin());
+    // run on device
+    thrust::reduce_by_key(thrust::device,
+                          d_keys.begin(),
+                          d_keys.end(),
+                          d_values.begin(),
+                          thrust::discard_iterator<T>{},
+                          thrust::make_transform_output_iterator(d_result.begin(),
+                                                                 thrust::negate<T>()));
+
+    ASSERT_EQUAL(h_result, d_result);
+  }
+};
+VariableUnitTest<TestTransformOutputIteratorReduceByKey, SignedIntegralTypes>
+  TestTransformOutputIteratorReduceByKeyInstance;

--- a/testing/transform_output_iterator.cu
+++ b/testing/transform_output_iterator.cu
@@ -1,11 +1,13 @@
 #include <unittest/unittest.h>
-#include <thrust/iterator/transform_output_iterator.h>
 
 #include <thrust/copy.h>
-#include <thrust/reduce.h>
+#include <thrust/device_vector.h>
 #include <thrust/functional.h>
-#include <thrust/sequence.h>
+#include <thrust/host_vector.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_output_iterator.h>
+#include <thrust/reduce.h>
+#include <thrust/sequence.h>
 
 template <class Vector>
 void TestTransformOutputIterator(void)
@@ -88,40 +90,3 @@ struct TestTransformOutputIteratorScan
     }
 };
 VariableUnitTest<TestTransformOutputIteratorScan, SignedIntegralTypes> TestTransformOutputIteratorScanInstance;
-
-template <typename T>
-struct TestTransformOutputIteratorReduceByKey
-{
-  void operator()(const size_t n)
-  {
-    thrust::host_vector<T> h_keys = unittest::random_samples<T>(n);
-    thrust::sort(h_keys.begin(), h_keys.end());
-    thrust::device_vector<T> d_keys = h_keys;
-
-    thrust::host_vector<T> h_values   = unittest::random_samples<T>(n);
-    thrust::device_vector<T> d_values = h_values;
-
-    thrust::host_vector<T> h_result(n);
-    thrust::device_vector<T> d_result(n);
-
-    // run on host
-    thrust::reduce_by_key(thrust::host,
-                          h_keys.begin(),
-                          h_keys.end(),
-                          thrust::make_transform_iterator(h_values.begin(), thrust::negate<T>()),
-                          thrust::discard_iterator<T>{},
-                          h_result.begin());
-    // run on device
-    thrust::reduce_by_key(thrust::device,
-                          d_keys.begin(),
-                          d_keys.end(),
-                          d_values.begin(),
-                          thrust::discard_iterator<T>{},
-                          thrust::make_transform_output_iterator(d_result.begin(),
-                                                                 thrust::negate<T>()));
-
-    ASSERT_EQUAL(h_result, d_result);
-  }
-};
-VariableUnitTest<TestTransformOutputIteratorReduceByKey, SignedIntegralTypes>
-  TestTransformOutputIteratorReduceByKeyInstance;

--- a/testing/transform_output_iterator_reduce_by_key.cu
+++ b/testing/transform_output_iterator_reduce_by_key.cu
@@ -48,3 +48,4 @@ struct TestTransformOutputIteratorReduceByKey
 };
 VariableUnitTest<TestTransformOutputIteratorReduceByKey, SignedIntegralTypes>
   TestTransformOutputIteratorReduceByKeyInstance;
+

--- a/testing/transform_output_iterator_reduce_by_key.cu
+++ b/testing/transform_output_iterator_reduce_by_key.cu
@@ -1,0 +1,50 @@
+#include <unittest/unittest.h>
+
+#include <thrust/copy.h>
+#include <thrust/device_vector.h>
+#include <thrust/functional.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/transform_output_iterator.h>
+#include <thrust/reduce.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+
+template <typename T>
+struct TestTransformOutputIteratorReduceByKey
+{
+  void operator()(const size_t n)
+  {
+    thrust::host_vector<T> h_keys = unittest::random_samples<T>(n);
+    thrust::sort(h_keys.begin(), h_keys.end());
+    thrust::device_vector<T> d_keys = h_keys;
+
+    thrust::host_vector<T> h_values   = unittest::random_samples<T>(n);
+    thrust::device_vector<T> d_values = h_values;
+
+    thrust::host_vector<T> h_result(n);
+    thrust::device_vector<T> d_result(n);
+
+    // run on host
+    thrust::reduce_by_key(thrust::host,
+                          h_keys.begin(),
+                          h_keys.end(),
+                          thrust::make_transform_iterator(h_values.begin(), thrust::negate<T>()),
+                          thrust::discard_iterator<T>{},
+                          h_result.begin());
+    // run on device
+    thrust::reduce_by_key(thrust::device,
+                          d_keys.begin(),
+                          d_keys.end(),
+                          d_values.begin(),
+                          thrust::discard_iterator<T>{},
+                          thrust::make_transform_output_iterator(d_result.begin(),
+                                                                 thrust::negate<T>()));
+
+    ASSERT_EQUAL(h_result, d_result);
+  }
+};
+VariableUnitTest<TestTransformOutputIteratorReduceByKey, SignedIntegralTypes>
+  TestTransformOutputIteratorReduceByKeyInstance;

--- a/thrust/iterator/transform_input_output_iterator.h
+++ b/thrust/iterator/transform_input_output_iterator.h
@@ -161,3 +161,4 @@ make_transform_input_output_iterator(Iterator io, InputFunction input_function, 
  */
 
 THRUST_NAMESPACE_END
+

--- a/thrust/iterator/transform_input_output_iterator.h
+++ b/thrust/iterator/transform_input_output_iterator.h
@@ -100,9 +100,7 @@ public:
   /*! \endcond
    */
 
-  /*! Null constructor does nothing.
-   */
-  __host__ __device__ transform_input_output_iterator() {}
+  transform_input_output_iterator() = default;
 
   /*! This constructor takes as argument a \c Iterator an \c InputFunction and an
    * \c OutputFunction and copies them to a new \p transform_input_output_iterator

--- a/thrust/iterator/transform_input_output_iterator.h
+++ b/thrust/iterator/transform_input_output_iterator.h
@@ -100,7 +100,9 @@ public:
   /*! \endcond
    */
 
-  transform_input_output_iterator() = default;
+  /*! Null constructor does nothing.
+   */
+  __host__ __device__ transform_input_output_iterator() {}
 
   /*! This constructor takes as argument a \c Iterator an \c InputFunction and an
    * \c OutputFunction and copies them to a new \p transform_input_output_iterator

--- a/thrust/iterator/transform_input_output_iterator.h
+++ b/thrust/iterator/transform_input_output_iterator.h
@@ -62,7 +62,7 @@ THRUST_NAMESPACE_BEGIN
  *    // Iterator that returns negated values and writes squared values
  *    auto iter = thrust::make_transform_input_output_iterator(v.begin(),
  *        thrust::negate<float>{}, thrust::square<float>{});
- *
+ * 
  *    // Iterator negates values when reading
  *    std::cout << iter[0] << " ";  // -1.0f;
  *    std::cout << iter[1] << " ";  // -2.0f;
@@ -85,24 +85,22 @@ THRUST_NAMESPACE_BEGIN
  */
 
 template <typename InputFunction, typename OutputFunction, typename Iterator>
-class transform_input_output_iterator
+  class transform_input_output_iterator
     : public detail::transform_input_output_iterator_base<InputFunction, OutputFunction, Iterator>::type
 {
 
   /*! \cond
    */
 
-public:
-  typedef typename detail::
-    transform_input_output_iterator_base<InputFunction, OutputFunction, Iterator>::type super_t;
+  public:
 
-  friend class thrust::iterator_core_access;
+    typedef typename
+    detail::transform_input_output_iterator_base<InputFunction, OutputFunction, Iterator>::type
+    super_t;
+
+    friend class thrust::iterator_core_access;
   /*! \endcond
    */
-
-  /*! Null constructor does nothing.
-   */
-  __host__ __device__ transform_input_output_iterator() {}
 
   /*! This constructor takes as argument a \c Iterator an \c InputFunction and an
    * \c OutputFunction and copies them to a new \p transform_input_output_iterator
@@ -112,30 +110,29 @@ public:
    * \param input_function An \c InputFunction to be executed on values read from the iterator
    * \param output_function An \c OutputFunction to be executed on values written to the iterator
    */
-  __host__ __device__ transform_input_output_iterator(Iterator const &io,
-                                                      InputFunction input_function,
-                                                      OutputFunction output_function)
-      : super_t(io)
-      , input_function(input_function)
-      , output_function(output_function)
-  {}
+    __host__ __device__
+    transform_input_output_iterator(Iterator const& io, InputFunction input_function, OutputFunction output_function)
+      : super_t(io), input_function(input_function), output_function(output_function)
+    {
+    }
 
-  /*! \cond
-   */
-private:
-  __host__ __device__ typename super_t::reference dereference() const
-  {
-    return detail::transform_input_output_iterator_proxy<InputFunction, OutputFunction, Iterator>(
-      this->base_reference(),
-      input_function,
-      output_function);
-  }
+    /*! \cond
+     */
+  private:
 
-  InputFunction input_function;
-  OutputFunction output_function;
+    __host__ __device__
+    typename super_t::reference dereference() const
+    {
+      return detail::transform_input_output_iterator_proxy<
+        InputFunction, OutputFunction, Iterator
+      >(this->base_reference(), input_function, output_function);
+    }
 
-  /*! \endcond
-   */
+    InputFunction input_function;
+    OutputFunction output_function;
+
+    /*! \endcond
+     */
 }; // end transform_input_output_iterator
 
 /*! \p make_transform_input_output_iterator creates a \p transform_input_output_iterator from
@@ -149,13 +146,10 @@ private:
  */
 template <typename InputFunction, typename OutputFunction, typename Iterator>
 transform_input_output_iterator<InputFunction, OutputFunction, Iterator>
-  __host__ __device__ make_transform_input_output_iterator(Iterator io,
-                                                           InputFunction input_function,
-                                                           OutputFunction output_function)
+__host__ __device__
+make_transform_input_output_iterator(Iterator io, InputFunction input_function, OutputFunction output_function)
 {
-  return transform_input_output_iterator<InputFunction, OutputFunction, Iterator>(io,
-                                                                                  input_function,
-                                                                                  output_function);
+    return transform_input_output_iterator<InputFunction, OutputFunction, Iterator>(io, input_function, output_function);
 } // end make_transform_input_output_iterator
 
 /*! \} // end fancyiterators
@@ -165,3 +159,4 @@ transform_input_output_iterator<InputFunction, OutputFunction, Iterator>
  */
 
 THRUST_NAMESPACE_END
+

--- a/thrust/iterator/transform_input_output_iterator.h
+++ b/thrust/iterator/transform_input_output_iterator.h
@@ -102,6 +102,8 @@ template <typename InputFunction, typename OutputFunction, typename Iterator>
   /*! \endcond
    */
 
+  transform_input_output_iterator() = default;
+
   /*! This constructor takes as argument a \c Iterator an \c InputFunction and an
    * \c OutputFunction and copies them to a new \p transform_input_output_iterator
    *
@@ -159,4 +161,3 @@ make_transform_input_output_iterator(Iterator io, InputFunction input_function, 
  */
 
 THRUST_NAMESPACE_END
-

--- a/thrust/iterator/transform_input_output_iterator.h
+++ b/thrust/iterator/transform_input_output_iterator.h
@@ -62,7 +62,7 @@ THRUST_NAMESPACE_BEGIN
  *    // Iterator that returns negated values and writes squared values
  *    auto iter = thrust::make_transform_input_output_iterator(v.begin(),
  *        thrust::negate<float>{}, thrust::square<float>{});
- * 
+ *
  *    // Iterator negates values when reading
  *    std::cout << iter[0] << " ";  // -1.0f;
  *    std::cout << iter[1] << " ";  // -2.0f;
@@ -85,22 +85,24 @@ THRUST_NAMESPACE_BEGIN
  */
 
 template <typename InputFunction, typename OutputFunction, typename Iterator>
-  class transform_input_output_iterator
+class transform_input_output_iterator
     : public detail::transform_input_output_iterator_base<InputFunction, OutputFunction, Iterator>::type
 {
 
   /*! \cond
    */
 
-  public:
+public:
+  typedef typename detail::
+    transform_input_output_iterator_base<InputFunction, OutputFunction, Iterator>::type super_t;
 
-    typedef typename
-    detail::transform_input_output_iterator_base<InputFunction, OutputFunction, Iterator>::type
-    super_t;
-
-    friend class thrust::iterator_core_access;
+  friend class thrust::iterator_core_access;
   /*! \endcond
    */
+
+  /*! Null constructor does nothing.
+   */
+  __host__ __device__ transform_input_output_iterator() {}
 
   /*! This constructor takes as argument a \c Iterator an \c InputFunction and an
    * \c OutputFunction and copies them to a new \p transform_input_output_iterator
@@ -110,29 +112,30 @@ template <typename InputFunction, typename OutputFunction, typename Iterator>
    * \param input_function An \c InputFunction to be executed on values read from the iterator
    * \param output_function An \c OutputFunction to be executed on values written to the iterator
    */
-    __host__ __device__
-    transform_input_output_iterator(Iterator const& io, InputFunction input_function, OutputFunction output_function)
-      : super_t(io), input_function(input_function), output_function(output_function)
-    {
-    }
+  __host__ __device__ transform_input_output_iterator(Iterator const &io,
+                                                      InputFunction input_function,
+                                                      OutputFunction output_function)
+      : super_t(io)
+      , input_function(input_function)
+      , output_function(output_function)
+  {}
 
-    /*! \cond
-     */
-  private:
+  /*! \cond
+   */
+private:
+  __host__ __device__ typename super_t::reference dereference() const
+  {
+    return detail::transform_input_output_iterator_proxy<InputFunction, OutputFunction, Iterator>(
+      this->base_reference(),
+      input_function,
+      output_function);
+  }
 
-    __host__ __device__
-    typename super_t::reference dereference() const
-    {
-      return detail::transform_input_output_iterator_proxy<
-        InputFunction, OutputFunction, Iterator
-      >(this->base_reference(), input_function, output_function);
-    }
+  InputFunction input_function;
+  OutputFunction output_function;
 
-    InputFunction input_function;
-    OutputFunction output_function;
-
-    /*! \endcond
-     */
+  /*! \endcond
+   */
 }; // end transform_input_output_iterator
 
 /*! \p make_transform_input_output_iterator creates a \p transform_input_output_iterator from
@@ -146,10 +149,13 @@ template <typename InputFunction, typename OutputFunction, typename Iterator>
  */
 template <typename InputFunction, typename OutputFunction, typename Iterator>
 transform_input_output_iterator<InputFunction, OutputFunction, Iterator>
-__host__ __device__
-make_transform_input_output_iterator(Iterator io, InputFunction input_function, OutputFunction output_function)
+  __host__ __device__ make_transform_input_output_iterator(Iterator io,
+                                                           InputFunction input_function,
+                                                           OutputFunction output_function)
 {
-    return transform_input_output_iterator<InputFunction, OutputFunction, Iterator>(io, input_function, output_function);
+  return transform_input_output_iterator<InputFunction, OutputFunction, Iterator>(io,
+                                                                                  input_function,
+                                                                                  output_function);
 } // end make_transform_input_output_iterator
 
 /*! \} // end fancyiterators
@@ -159,4 +165,3 @@ make_transform_input_output_iterator(Iterator io, InputFunction input_function, 
  */
 
 THRUST_NAMESPACE_END
-

--- a/thrust/iterator/transform_output_iterator.h
+++ b/thrust/iterator/transform_output_iterator.h
@@ -38,7 +38,7 @@ THRUST_NAMESPACE_BEGIN
 /*! \p transform_output_iterator is a special kind of output iterator which
  * transforms a value written upon dereference. This iterator is useful
  * for transforming an output from algorithms without explicitly storing the
- * intermediate result in the memory and applying subsequent transformation,
+ * intermediate result in the memory and applying subsequent transformation, 
  * thereby avoiding wasting memory capacity and bandwidth.
  * Using \p transform_iterator facilitates kernel fusion by deferring execution
  * of transformation until the value is written while saving both memory
@@ -61,7 +61,7 @@ THRUST_NAMESPACE_BEGIN
  *      return sqrtf(x);
  *    }
  *  };
- *
+ *  
  *  int main()
  *  {
  *    thrust::device_vector<float> v(4);
@@ -69,17 +69,17 @@ THRUST_NAMESPACE_BEGIN
  *    typedef thrust::device_vector<float>::iterator FloatIterator;
  *    thrust::transform_output_iterator<square_root, FloatIterator> iter(v.begin(), square_root());
  *
- *    iter[0] =  1.0f;    // stores sqrtf( 1.0f)
+ *    iter[0] =  1.0f;    // stores sqrtf( 1.0f) 
  *    iter[1] =  4.0f;    // stores sqrtf( 4.0f)
  *    iter[2] =  9.0f;    // stores sqrtf( 9.0f)
  *    iter[3] = 16.0f;    // stores sqrtf(16.0f)
  *    // iter[4] is an out-of-bounds error
- *
+ *                                                                                           
  *    v[0]; // returns 1.0f;
  *    v[1]; // returns 2.0f;
  *    v[2]; // returns 3.0f;
  *    v[3]; // returns 4.0f;
- *
+ *                                                                                           
  *  }
  *  \endcode
  *
@@ -87,52 +87,52 @@ THRUST_NAMESPACE_BEGIN
  */
 
 template <typename UnaryFunction, typename OutputIterator>
-class transform_output_iterator
+  class transform_output_iterator
     : public detail::transform_output_iterator_base<UnaryFunction, OutputIterator>::type
 {
 
   /*! \cond
    */
 
-public:
-  typedef
-    typename detail::transform_output_iterator_base<UnaryFunction, OutputIterator>::type super_t;
+  public:
 
-  friend class thrust::iterator_core_access;
+    typedef typename
+    detail::transform_output_iterator_base<UnaryFunction, OutputIterator>::type
+    super_t;
+
+    friend class thrust::iterator_core_access;
   /*! \endcond
    */
-
-  /*! Null constructor does nothing.
-   */
-  __host__ __device__ transform_output_iterator() {}
 
   /*! This constructor takes as argument an \c OutputIterator and an \c
    * UnaryFunction and copies them to a new \p transform_output_iterator
    *
-   * \param out An \c OutputIterator pointing to the output range whereto the result of
+   * \param out An \c OutputIterator pointing to the output range whereto the result of 
    *            \p transform_output_iterator's \c UnaryFunction will be written.
    * \param fun An \c UnaryFunction used to transform the objects assigned to
    *            this \p transform_output_iterator.
    */
-  __host__ __device__ transform_output_iterator(OutputIterator const &out, UnaryFunction fun)
-      : super_t(out)
-      , fun(fun)
-  {}
+    __host__ __device__
+    transform_output_iterator(OutputIterator const& out, UnaryFunction fun) : super_t(out), fun(fun)
+    {
+    }
 
-  /*! \cond
-   */
-private:
-  __host__ __device__ typename super_t::reference dereference() const
-  {
-    return detail::transform_output_iterator_proxy<UnaryFunction, OutputIterator>(
-      this->base_reference(),
-      fun);
-  }
+    /*! \cond
+     */
+  private:
 
-  UnaryFunction fun;
+    __host__ __device__
+    typename super_t::reference dereference() const
+    {
+      return detail::transform_output_iterator_proxy<
+        UnaryFunction, OutputIterator
+      >(this->base_reference(), fun);
+    }
 
-  /*! \endcond
-   */
+    UnaryFunction fun;
+
+    /*! \endcond
+     */
 }; // end transform_output_iterator
 
 /*! \p make_transform_output_iterator creates a \p transform_output_iterator from
@@ -146,9 +146,10 @@ private:
  */
 template <typename UnaryFunction, typename OutputIterator>
 transform_output_iterator<UnaryFunction, OutputIterator>
-  __host__ __device__ make_transform_output_iterator(OutputIterator out, UnaryFunction fun)
+__host__ __device__
+make_transform_output_iterator(OutputIterator out, UnaryFunction fun)
 {
-  return transform_output_iterator<UnaryFunction, OutputIterator>(out, fun);
+    return transform_output_iterator<UnaryFunction, OutputIterator>(out, fun);
 } // end make_transform_output_iterator
 
 /*! \} // end fancyiterators
@@ -158,3 +159,4 @@ transform_output_iterator<UnaryFunction, OutputIterator>
  */
 
 THRUST_NAMESPACE_END
+

--- a/thrust/iterator/transform_output_iterator.h
+++ b/thrust/iterator/transform_output_iterator.h
@@ -161,3 +161,4 @@ make_transform_output_iterator(OutputIterator out, UnaryFunction fun)
  */
 
 THRUST_NAMESPACE_END
+

--- a/thrust/iterator/transform_output_iterator.h
+++ b/thrust/iterator/transform_output_iterator.h
@@ -38,7 +38,7 @@ THRUST_NAMESPACE_BEGIN
 /*! \p transform_output_iterator is a special kind of output iterator which
  * transforms a value written upon dereference. This iterator is useful
  * for transforming an output from algorithms without explicitly storing the
- * intermediate result in the memory and applying subsequent transformation, 
+ * intermediate result in the memory and applying subsequent transformation,
  * thereby avoiding wasting memory capacity and bandwidth.
  * Using \p transform_iterator facilitates kernel fusion by deferring execution
  * of transformation until the value is written while saving both memory
@@ -61,7 +61,7 @@ THRUST_NAMESPACE_BEGIN
  *      return sqrtf(x);
  *    }
  *  };
- *  
+ *
  *  int main()
  *  {
  *    thrust::device_vector<float> v(4);
@@ -69,17 +69,17 @@ THRUST_NAMESPACE_BEGIN
  *    typedef thrust::device_vector<float>::iterator FloatIterator;
  *    thrust::transform_output_iterator<square_root, FloatIterator> iter(v.begin(), square_root());
  *
- *    iter[0] =  1.0f;    // stores sqrtf( 1.0f) 
+ *    iter[0] =  1.0f;    // stores sqrtf( 1.0f)
  *    iter[1] =  4.0f;    // stores sqrtf( 4.0f)
  *    iter[2] =  9.0f;    // stores sqrtf( 9.0f)
  *    iter[3] = 16.0f;    // stores sqrtf(16.0f)
  *    // iter[4] is an out-of-bounds error
- *                                                                                           
+ *
  *    v[0]; // returns 1.0f;
  *    v[1]; // returns 2.0f;
  *    v[2]; // returns 3.0f;
  *    v[3]; // returns 4.0f;
- *                                                                                           
+ *
  *  }
  *  \endcode
  *
@@ -87,52 +87,52 @@ THRUST_NAMESPACE_BEGIN
  */
 
 template <typename UnaryFunction, typename OutputIterator>
-  class transform_output_iterator
+class transform_output_iterator
     : public detail::transform_output_iterator_base<UnaryFunction, OutputIterator>::type
 {
 
   /*! \cond
    */
 
-  public:
+public:
+  typedef
+    typename detail::transform_output_iterator_base<UnaryFunction, OutputIterator>::type super_t;
 
-    typedef typename
-    detail::transform_output_iterator_base<UnaryFunction, OutputIterator>::type
-    super_t;
-
-    friend class thrust::iterator_core_access;
+  friend class thrust::iterator_core_access;
   /*! \endcond
    */
+
+  /*! Null constructor does nothing.
+   */
+  __host__ __device__ transform_output_iterator() {}
 
   /*! This constructor takes as argument an \c OutputIterator and an \c
    * UnaryFunction and copies them to a new \p transform_output_iterator
    *
-   * \param out An \c OutputIterator pointing to the output range whereto the result of 
+   * \param out An \c OutputIterator pointing to the output range whereto the result of
    *            \p transform_output_iterator's \c UnaryFunction will be written.
    * \param fun An \c UnaryFunction used to transform the objects assigned to
    *            this \p transform_output_iterator.
    */
-    __host__ __device__
-    transform_output_iterator(OutputIterator const& out, UnaryFunction fun) : super_t(out), fun(fun)
-    {
-    }
+  __host__ __device__ transform_output_iterator(OutputIterator const &out, UnaryFunction fun)
+      : super_t(out)
+      , fun(fun)
+  {}
 
-    /*! \cond
-     */
-  private:
+  /*! \cond
+   */
+private:
+  __host__ __device__ typename super_t::reference dereference() const
+  {
+    return detail::transform_output_iterator_proxy<UnaryFunction, OutputIterator>(
+      this->base_reference(),
+      fun);
+  }
 
-    __host__ __device__
-    typename super_t::reference dereference() const
-    {
-      return detail::transform_output_iterator_proxy<
-        UnaryFunction, OutputIterator
-      >(this->base_reference(), fun);
-    }
+  UnaryFunction fun;
 
-    UnaryFunction fun;
-
-    /*! \endcond
-     */
+  /*! \endcond
+   */
 }; // end transform_output_iterator
 
 /*! \p make_transform_output_iterator creates a \p transform_output_iterator from
@@ -146,10 +146,9 @@ template <typename UnaryFunction, typename OutputIterator>
  */
 template <typename UnaryFunction, typename OutputIterator>
 transform_output_iterator<UnaryFunction, OutputIterator>
-__host__ __device__
-make_transform_output_iterator(OutputIterator out, UnaryFunction fun)
+  __host__ __device__ make_transform_output_iterator(OutputIterator out, UnaryFunction fun)
 {
-    return transform_output_iterator<UnaryFunction, OutputIterator>(out, fun);
+  return transform_output_iterator<UnaryFunction, OutputIterator>(out, fun);
 } // end make_transform_output_iterator
 
 /*! \} // end fancyiterators
@@ -159,4 +158,3 @@ make_transform_output_iterator(OutputIterator out, UnaryFunction fun)
  */
 
 THRUST_NAMESPACE_END
-

--- a/thrust/iterator/transform_output_iterator.h
+++ b/thrust/iterator/transform_output_iterator.h
@@ -104,6 +104,8 @@ template <typename UnaryFunction, typename OutputIterator>
   /*! \endcond
    */
 
+  transform_output_iterator() = default;
+
   /*! This constructor takes as argument an \c OutputIterator and an \c
    * UnaryFunction and copies them to a new \p transform_output_iterator
    *
@@ -159,4 +161,3 @@ make_transform_output_iterator(OutputIterator out, UnaryFunction fun)
  */
 
 THRUST_NAMESPACE_END
-

--- a/thrust/iterator/transform_output_iterator.h
+++ b/thrust/iterator/transform_output_iterator.h
@@ -102,9 +102,7 @@ public:
   /*! \endcond
    */
 
-  /*! Null constructor does nothing.
-   */
-  __host__ __device__ transform_output_iterator() {}
+  transform_output_iterator() = default;
 
   /*! This constructor takes as argument an \c OutputIterator and an \c
    * UnaryFunction and copies them to a new \p transform_output_iterator

--- a/thrust/iterator/transform_output_iterator.h
+++ b/thrust/iterator/transform_output_iterator.h
@@ -102,7 +102,9 @@ public:
   /*! \endcond
    */
 
-  transform_output_iterator() = default;
+  /*! Null constructor does nothing.
+   */
+  __host__ __device__ transform_output_iterator() {}
 
   /*! This constructor takes as argument an \c OutputIterator and an \c
    * UnaryFunction and copies them to a new \p transform_output_iterator


### PR DESCRIPTION
Fixes #1804 

This PR adds default constructors to `transform_output_iterator` and `transform_input_output_iterator`. It also adds a unit test of `transform_output_iterator` with `reduce_by_key` which fails to compile before this change. With this change it compiles and runs correctly.

All other Thrust fancy iterators have default constructors, so I think this change improves consistency.

Sorry about all the formatting changes -- Thrust includes a `.clang-format`, but apparently doesn't use it to format files, so when I saved these files, clang-format reformatted them (I have format-on-save enabled). If this is a problem, I can resubmit without clang-formatting.  To review just the functional changes, look for `TestTransformOutputIteratorReduceByKey`, and in the headers look for `= default`