### PR TITLE
Fix some warning about usage of `__host__` functions in `__device__` code

### DIFF
--- a/thrust/device_new_allocator.h
+++ b/thrust/device_new_allocator.h
@@ -25,7 +25,10 @@
 #include <thrust/device_reference.h>
 #include <thrust/device_new.h>
 #include <thrust/device_delete.h>
-#include <limits>
+
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+
 #include <stdexcept>
 
 THRUST_NAMESPACE_BEGIN
@@ -61,8 +64,8 @@ template<typename T>
     /*! \c const reference to allocated element, \c device_reference<const T>. */
     typedef device_reference<const T>         const_reference;
 
-    /*! Type of allocation size, \c std::size_t. */
-    typedef std::size_t                       size_type;
+    /*! Type of allocation size, \c ::cuda::std::size_t. */
+    typedef ::cuda::std::size_t                 size_type;
 
     /*! Type of allocation difference, \c pointer::difference_type. */
     typedef typename pointer::difference_type difference_type;
@@ -147,7 +150,7 @@ template<typename T>
     __host__ __device__
     inline size_type max_size() const
     {
-      return std::numeric_limits<size_type>::max THRUST_PREVENT_MACRO_SUBSTITUTION () / sizeof(T);
+      return ::cuda::std::numeric_limits<size_type>::max THRUST_PREVENT_MACRO_SUBSTITUTION () / sizeof(T);
     } // end max_size()
 
     /*! Compares against another \p device_malloc_allocator for equality.

--- a/thrust/optional.h
+++ b/thrust/optional.h
@@ -1580,7 +1580,7 @@ public:
 
     *this = nullopt;
     this->construct(std::forward<Args>(args)...);
-    return value();
+    return this->m_value;
   }
 
   /// \group emplace
@@ -1594,7 +1594,7 @@ public:
   emplace(std::initializer_list<U> il, Args &&... args) {
     *this = nullopt;
     this->construct(il, std::forward<Args>(args)...);
-    return value();
+    return this->m_value;
   }
 
   /// Swaps this optional with the other.


### PR DESCRIPTION
Internal CI improved handling of warnings so we goth those two new warnings about `__host__` functions in `__device__` code.

Luckily those are easy to work around

P.S. yes there is a typo but 🧛 