### PR TITLE
Reduce large keys test

### DIFF
--- a/testing/stable_sort_large.cu
+++ b/testing/stable_sort_large.cu
@@ -24,22 +24,9 @@ void _TestStableSortWithLargeKeys(void)
 
 void TestStableSortWithLargeKeys(void)
 {
-    _TestStableSortWithLargeKeys<int,    1>();
     _TestStableSortWithLargeKeys<int,    2>();
-    _TestStableSortWithLargeKeys<int,    4>();
-    _TestStableSortWithLargeKeys<int,    8>();
-    _TestStableSortWithLargeKeys<int,   16>();
-    _TestStableSortWithLargeKeys<int,   32>();
-    _TestStableSortWithLargeKeys<int,   64>();
+    _TestStableSortWithLargeKeys<int,   17>();
     _TestStableSortWithLargeKeys<int,  128>();
-    _TestStableSortWithLargeKeys<int,  256>();
-
-// XXX these take too long to compile
-//    _TestStableSortWithLargeKeys<int,  512>();
-//    _TestStableSortWithLargeKeys<int, 1024>();
-//    _TestStableSortWithLargeKeys<int, 2048>();
-//    _TestStableSortWithLargeKeys<int, 4096>();
-//    _TestStableSortWithLargeKeys<int, 8192>();
 }
 DECLARE_UNITTEST(TestStableSortWithLargeKeys);
 


### PR DESCRIPTION
I don't think that we have to cover every power of two to test stable sort on large keys. The test, basically, has to test that large keys are supported. I'd consider anything larger than 128 bits to be large in this case. Judging from the code path coverage perspective, this test is going to be using `cub::DeviceMergeSort::StableSortKeys`. There are two code paths dependent on the key size. If the thread block tile size fits into 48 KB, shared memory is used. Otherwise, we allocate virtual (global) shared memory. Using 128 items in this test leads to 128 KB tile size, which is far beyond 48 KB limit. To test the other part of the spectrum we can select more interesting (non-power-of-two) example that uses, say, 17 items. 

This change makes `thrust.test.stable_sort_large` build 3x faster. 