### PR TITLE
Correct install(PATTERN) to match end of filenames

### DIFF
--- a/cmake/ThrustInstallRules.cmake
+++ b/cmake/ThrustInstallRules.cmake
@@ -13,7 +13,7 @@ install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust"
 
 install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust/cmake/"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/thrust"
-  PATTERN thrust-header-search EXCLUDE
+  PATTERN *.cmake.in EXCLUDE
 )
 # Need to configure a file to store the infix specified in
 # CMAKE_INSTALL_INCLUDEDIR since it can be defined by the user


### PR DESCRIPTION
The `PATTERN` matches at the end of filenames not the front, so we need to specify `*.cmake.in` to exclude the template files.