### PR TITLE
Fix reduce by key for non default initializable iterators

### DIFF
--- a/thrust/system/cuda/detail/reduce_by_key.h
+++ b/thrust/system/cuda/detail/reduce_by_key.h
@@ -1079,12 +1079,13 @@ namespace __reduce_by_key {
 
     size_type num_items = thrust::distance(keys_first, keys_last);
 
+    pair<KeysOutputIt, ValuesOutputIt> result = thrust::make_pair(keys_output, values_output);
+
     if (num_items == 0)
     {
-      return thrust::make_pair(keys_output, values_output);
+      return result;
     }
 
-    pair<KeysOutputIt, ValuesOutputIt> result{};
     THRUST_INDEX_TYPE_DISPATCH(result,
                                reduce_by_key_dispatch,
                                num_items,


### PR DESCRIPTION
This PR fixes the following [issue](https://github.com/NVIDIA/thrust/issues/1826) for bug introduced in the following [PR](https://github.com/NVIDIA/thrust/pull/1671).