### PR TITLE
Fix syntax error in example in documentation.

### DIFF
--- a/thrust/execution_policy.h
+++ b/thrust/execution_policy.h
@@ -282,8 +282,7 @@ template<typename DerivedPolicy>
  *    }
  *  };
  *  ...
- *  int vec[3];
- *  vec[0] = 0; vec[1] = 1; vec[2] = 2;
+ *  int vec[] = { 0, 1, 2 };
  *
  *  thrust::for_each(thrust::host, vec, vec + 3, printf_functor());
  *

--- a/thrust/execution_policy.h
+++ b/thrust/execution_policy.h
@@ -282,10 +282,10 @@ template<typename DerivedPolicy>
  *    }
  *  };
  *  ...
- *  int vec(3);
+ *  int vec[3];
  *  vec[0] = 0; vec[1] = 1; vec[2] = 2;
  *
- *  thrust::for_each(thrust::host, vec.begin(), vec.end(), printf_functor());
+ *  thrust::for_each(thrust::host, vec, vec + 3, printf_functor());
  *
  *  // 0 1 2 is printed to standard output in some unspecified order
  *  \endcode


### PR DESCRIPTION
Example was not syntaxically correct:

```c++
int vec(3);
vec[0] = 0; vec[1] = 1; vec[2] = 2;
thrust::for_each(thrust::host, vec.begin(), vec.end(), printf_functor());
```