### PR TITLE
Thrust: providing the error messages about the lack of GPU or a GPU w…

### DIFF
--- a/thrust/system/cuda/detail/core/agent_launcher.h
+++ b/thrust/system/cuda/detail/core/agent_launcher.h
@@ -475,9 +475,7 @@ namespace core {
 #ifdef __CUDACC_RDC__
       return core::get_agent_plan<Agent>(s, d_ptr);
 #else
-      core::cuda_optional<int> ptx_version = core::get_ptx_version();
-      //CUDA_CUB_RET_IF_FAIL(ptx_version.status());
-      return get_agent_plan<Agent>(ptx_version);
+      return get_agent_plan<Agent>(core::get_ptx_version());
 #endif
     }
     THRUST_RUNTIME_FUNCTION
@@ -527,7 +525,7 @@ namespace core {
     {
       #if THRUST_DEBUG_SYNC_FLAG 
       cuda_optional<int> occ = max_sm_occupancy(k);
-      core::cuda_optional<int> ptx_version = core::get_ptx_version();
+      const int ptx_version = core::get_ptx_version();
       if (count > 0)
       {
         _CubLog("Invoking %s<<<%u, %d, %d, %lld>>>(), %llu items total, %d items per thread, %d SM occupancy, %d vshmem size, %d ptx_version \n",

--- a/thrust/system/cuda/detail/core/agent_launcher.h
+++ b/thrust/system/cuda/detail/core/agent_launcher.h
@@ -491,8 +491,7 @@ namespace core {
     typename core::get_plan<Agent>::type static get_plan(cudaStream_t , void* d_ptr = 0)
     {
       THRUST_UNUSED_VAR(d_ptr);
-      core::cuda_optional<int> ptx_version = core::get_ptx_version();
-      return get_agent_plan<Agent>(ptx_version);
+      return get_agent_plan<Agent>(core::get_ptx_version());
     }
 
     THRUST_RUNTIME_FUNCTION

--- a/thrust/system/cuda/detail/core/util.h
+++ b/thrust/system/cuda/detail/core/util.h
@@ -618,7 +618,8 @@ namespace core {
   inline cuda_optional<int> get_ptx_version()
   {
     int ptx_version = 0;
-    cudaError_t status = cudaGetDevice(&device);
+    int dev_id = 0;
+    cudaError_t status = cudaGetDevice(&dev_id);
     if (status != cudaSuccess)
     {
       throw thrust::system_error(status, thrust::cuda_category(), "No GPU is available\n");
@@ -632,12 +633,12 @@ namespace core {
       int major = 0, minor = 0;
       cudaError_t attr_status;
 
-      attr_status = cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device);
+      attr_status = cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, dev_id);
       cuda_cub::throw_on_error(attr_status,
                               "get_ptx_version :"
                               "failed to get major CUDA device compute capability version.");
 
-      attr_status = cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device);
+      attr_status = cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, dev_id);
       cuda_cub::throw_on_error(attr_status,
                               "get_ptx_version :"
                               "failed to get minor CUDA device compute capability version.");

--- a/thrust/system/cuda/detail/core/util.h
+++ b/thrust/system/cuda/detail/core/util.h
@@ -648,7 +648,7 @@ namespace core {
       char str[] = "This program was not compiled for SM     \n";
 
       auto print_1_helper = [&](int v) {
-        str[code_offset] = v + '0';
+        str[code_offset] = static_cast<char>(v) + '0';
         code_offset++;
       };
 

--- a/thrust/system/cuda/detail/core/util.h
+++ b/thrust/system/cuda/detail/core/util.h
@@ -618,16 +618,18 @@ namespace core {
   THRUST_RUNTIME_FUNCTION
   inline int get_ptx_version()
   {
-    const int current_device = cub::CurrentDevice();
-    if (current_device < 0)
-    {
-      cuda_cub::throw_on_error(cudaErrorNoDevice, "No GPU is available\n");
-    }
-
-    // Any failure means the provided device binary does not match the generated function code
     int ptx_version = 0;
     if (cub::PtxVersion(ptx_version) != cudaSuccess) 
     {
+      // Failure might mean that there's no device found
+      const int current_device = cub::CurrentDevice();
+      if (current_device < 0)
+      {
+        cuda_cub::throw_on_error(cudaErrorNoDevice, "No GPU is available\n");
+      }
+
+      // Any subsequent failure means the provided device binary does not match 
+      // the generated function code
       int major = 0, minor = 0;
       cudaError_t attr_status;
 

--- a/thrust/system/cuda/detail/core/util.h
+++ b/thrust/system/cuda/detail/core/util.h
@@ -618,15 +618,14 @@ namespace core {
   THRUST_RUNTIME_FUNCTION
   inline int get_ptx_version()
   {
-    int ptx_version = 0;
     const int current_device = cub::CurrentDevice();
-
     if (current_device < 0)
     {
       cuda_cub::throw_on_error(cudaErrorNoDevice, "No GPU is available\n");
     }
 
     // Any failure means the provided device binary does not match the generated function code
+    int ptx_version = 0;
     if (cub::PtxVersion(ptx_version) != cudaSuccess) 
     {
       int major = 0, minor = 0;


### PR DESCRIPTION
To give a user some clue what's happening if the program gets compiled on a node with no GPU or if it gets compiled with different compute capability than the one it's running on. In both scenarios no good error message was produced before. The proposed changes will improve the user experience and make it easier for users to troubleshoot problems.

This fix is for addressing the issue#1785 reported on Thrust https://github.com/NVIDIA/thrust/issues/1785

From issue#1785 on thrust (https://github.com/NVIDIA/thrust/issues/1785), for this small test case:


`
#include <thrust/device_vector.h> 
#include <thrust/sort.h> 
int main() { 
thrust::device_vector<int> dv; 
thrust::sort(dv.begin(), dv.end()); 
}
`


when compiled with -gpu=cc60 and then run it on a system with cc80, the error message would be:

`
terminate called after throwing an instance of 'thrust::system::system_error' what():  radix_sort: failed on 1st step: cudaErrorUnsupportedPtxVersion: the provided PTX was compiled with an unsupported toolchain. Aborted
`

This doesn't help user to understand what's happening. I tried to address it in this change so that better message will show up:
Incompatible GPU: you are trying to run this program on sm_80, different from the one that it was compiled for.
