### PR TITLE
Disable device-side tests for Clang CUDA

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -110,6 +110,10 @@ function(thrust_add_example target_name_var example_name example_src thrust_targ
     thrust_enable_rdc_for_cuda_target(${example_target})
   endif()
 
+  if (NOT "Clang" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
+    target_compile_definitions(${example_target} PRIVATE THRUST_EXAMPLE_DEVICE_SIDE)
+  endif()
+
   # Get the name of FileCheck input by stripping out the config name.
   # (e.g. "thrust.cpp.cuda.cpp14.example.xxx" -> "thrust.example.xxx.filecheck")
   string(REPLACE "${config_prefix}" "thrust"

--- a/examples/cuda/async_reduce.cu
+++ b/examples/cuda/async_reduce.cu
@@ -21,11 +21,13 @@
 // std::future to wait for the result of the reduction. This method requires a compiler which supports
 // C++11-capable language and library constructs.
 
+#if THRUST_EXAMPLE_DEVICE_SIDE
 template<typename Iterator, typename T, typename BinaryOperation, typename Pointer>
 __global__ void reduce_kernel(Iterator first, Iterator last, T init, BinaryOperation binary_op, Pointer result)
 {
   *result = thrust::reduce(thrust::cuda::par, first, last, init, binary_op);
 }
+#endif
 
 int main()
 {
@@ -40,7 +42,11 @@ int main()
   cudaStreamCreate(&s);
 
   // launch a CUDA kernel with only 1 thread on our stream
+#if THRUST_EXAMPLE_DEVICE_SIDE
   reduce_kernel<<<1,1,0,s>>>(data.begin(), data.end(), 0, thrust::plus<int>(), result.data());
+#else
+  result[0] = thrust::reduce(thrust::cuda::par, data.begin(), data.end(), 0, thrust::plus<int>());
+#endif
 
   // wait for the stream to finish
   cudaStreamSynchronize(s);

--- a/examples/cuda/async_reduce.cu
+++ b/examples/cuda/async_reduce.cu
@@ -21,7 +21,7 @@
 // std::future to wait for the result of the reduction. This method requires a compiler which supports
 // C++11-capable language and library constructs.
 
-#if THRUST_EXAMPLE_DEVICE_SIDE
+#ifdef THRUST_EXAMPLE_DEVICE_SIDE
 template<typename Iterator, typename T, typename BinaryOperation, typename Pointer>
 __global__ void reduce_kernel(Iterator first, Iterator last, T init, BinaryOperation binary_op, Pointer result)
 {
@@ -42,7 +42,7 @@ int main()
   cudaStreamCreate(&s);
 
   // launch a CUDA kernel with only 1 thread on our stream
-#if THRUST_EXAMPLE_DEVICE_SIDE
+#ifdef THRUST_EXAMPLE_DEVICE_SIDE
   reduce_kernel<<<1,1,0,s>>>(data.begin(), data.end(), 0, thrust::plus<int>(), result.data());
 #else
   result[0] = thrust::reduce(thrust::cuda::par, data.begin(), data.end(), 0, thrust::plus<int>());

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -83,6 +83,10 @@ function(thrust_add_test target_name_var test_name test_src thrust_target)
   target_include_directories(${test_target} PRIVATE "${Thrust_SOURCE_DIR}/testing")
   thrust_clone_target_properties(${test_target} ${thrust_target})
 
+  if (NOT "Clang" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
+    target_compile_definitions(${test_target} PRIVATE THRUST_TEST_DEVICE_SIDE)
+  endif()
+
   # Add to the active configuration's meta target
   add_dependencies(${config_meta_target} ${test_target})
 

--- a/testing/cuda/adjacent_difference.cu
+++ b/testing/cuda/adjacent_difference.cu
@@ -5,7 +5,7 @@
 #include <thrust/device_free.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__ void adjacent_difference_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)
 {

--- a/testing/cuda/adjacent_difference.cu
+++ b/testing/cuda/adjacent_difference.cu
@@ -5,6 +5,7 @@
 #include <thrust/device_free.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__ void adjacent_difference_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)
 {
@@ -73,6 +74,7 @@ void TestAdjacentDifferenceDeviceDevice(const size_t n)
   TestAdjacentDifferenceDevice<T>(thrust::device, n);
 }
 DECLARE_VARIABLE_UNITTEST(TestAdjacentDifferenceDeviceDevice);
+#endif
 
 
 void TestAdjacentDifferenceCudaStreams()

--- a/testing/cuda/copy.cu
+++ b/testing/cuda/copy.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void copy_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)
@@ -89,4 +90,5 @@ void TestCopyNDeviceDevice(size_t n)
   TestCopyNDevice<T>(thrust::device, n);
 }
 DECLARE_VARIABLE_UNITTEST(TestCopyNDeviceDevice);
+#endif
 

--- a/testing/cuda/copy.cu
+++ b/testing/cuda/copy.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void copy_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)

--- a/testing/cuda/copy_if.cu
+++ b/testing/cuda/copy_if.cu
@@ -20,6 +20,7 @@ struct mod_3
 };
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Predicate, typename Iterator3>
 __global__ void copy_if_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result1, Predicate pred, Iterator3 result2)
 {
@@ -100,6 +101,7 @@ void TestCopyIfDeviceNoSync()
   TestCopyIfDevice(thrust::cuda::par_nosync);
 }
 DECLARE_UNITTEST(TestCopyIfDeviceNoSync);
+#endif
 
 template<typename ExecutionPolicy>
 void TestCopyIfCudaStreams(ExecutionPolicy policy)
@@ -143,6 +145,7 @@ void TestCopyIfCudaStreamsNoSync(){
 DECLARE_UNITTEST(TestCopyIfCudaStreamsNoSync);
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Predicate, typename Iterator4>
 __global__ void copy_if_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 stencil_first, Iterator3 result1, Predicate pred, Iterator4 result2)
 {
@@ -226,6 +229,7 @@ void TestCopyIfStencilDeviceNoSync()
   TestCopyIfStencilDevice(thrust::cuda::par_nosync);
 }
 DECLARE_UNITTEST(TestCopyIfStencilDeviceNoSync);
+#endif
 
 
 template<typename ExecutionPolicy>

--- a/testing/cuda/copy_if.cu
+++ b/testing/cuda/copy_if.cu
@@ -20,7 +20,7 @@ struct mod_3
 };
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Predicate, typename Iterator3>
 __global__ void copy_if_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result1, Predicate pred, Iterator3 result2)
 {
@@ -145,7 +145,7 @@ void TestCopyIfCudaStreamsNoSync(){
 DECLARE_UNITTEST(TestCopyIfCudaStreamsNoSync);
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Predicate, typename Iterator4>
 __global__ void copy_if_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 stencil_first, Iterator3 result1, Predicate pred, Iterator4 result2)
 {

--- a/testing/cuda/count.cu
+++ b/testing/cuda/count.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T, typename Iterator2>
 __global__
 void count_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T value, Iterator2 result)

--- a/testing/cuda/count.cu
+++ b/testing/cuda/count.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T, typename Iterator2>
 __global__
 void count_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T value, Iterator2 result)
@@ -91,6 +92,7 @@ void TestCountIfDeviceDevice(const size_t n)
   TestCountIfDevice<T>(thrust::device, n);
 }
 DECLARE_VARIABLE_UNITTEST(TestCountIfDeviceDevice);
+#endif
 
 
 void TestCountCudaStreams()

--- a/testing/cuda/equal.cu
+++ b/testing/cuda/equal.cu
@@ -4,7 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__
 void equal_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator3 result)

--- a/testing/cuda/equal.cu
+++ b/testing/cuda/equal.cu
@@ -4,6 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__
 void equal_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator3 result)
@@ -92,6 +93,7 @@ void TestEqualDeviceDevice(const size_t n)
   TestEqualDevice<T>(thrust::device, n);
 }
 DECLARE_VARIABLE_UNITTEST(TestEqualDeviceDevice);
+#endif
 
 
 void TestEqualCudaStreams()

--- a/testing/cuda/fill.cu
+++ b/testing/cuda/fill.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 #include <algorithm>
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T>
 __global__
 void fill_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T value)
@@ -169,6 +170,7 @@ void TestFillNDeviceDevice(size_t n)
   TestFillNDevice<T>(thrust::device, n);
 }
 DECLARE_VARIABLE_UNITTEST(TestFillNDeviceDevice);
+#endif
 
 void TestFillCudaStreams()
 {

--- a/testing/cuda/fill.cu
+++ b/testing/cuda/fill.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 #include <algorithm>
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T>
 __global__
 void fill_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T value)

--- a/testing/cuda/find.cu
+++ b/testing/cuda/find.cu
@@ -39,6 +39,7 @@ struct less_than_value_pred
 };
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T, typename Iterator2>
 __global__ void find_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T value, Iterator2 result)
 {
@@ -219,6 +220,7 @@ void TestFindIfNotDeviceDevice()
   TestFindIfNotDevice(thrust::device);
 };
 DECLARE_UNITTEST(TestFindIfNotDeviceDevice);
+#endif
 
 
 void TestFindCudaStreams()

--- a/testing/cuda/find.cu
+++ b/testing/cuda/find.cu
@@ -39,7 +39,7 @@ struct less_than_value_pred
 };
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T, typename Iterator2>
 __global__ void find_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T value, Iterator2 result)
 {

--- a/testing/cuda/for_each.cu
+++ b/testing/cuda/for_each.cu
@@ -59,6 +59,7 @@ struct mark_present_for_each
 };
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Function>
 __global__ void for_each_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f)
 {
@@ -202,6 +203,7 @@ void TestForEachNDeviceDevice(const size_t n)
   ASSERT_EQUAL(h_output, d_output);
 }
 DECLARE_VARIABLE_UNITTEST(TestForEachNDeviceDevice);
+#endif
 
 
 void TestForEachCudaStreams()

--- a/testing/cuda/for_each.cu
+++ b/testing/cuda/for_each.cu
@@ -59,7 +59,7 @@ struct mark_present_for_each
 };
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Function>
 __global__ void for_each_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f)
 {

--- a/testing/cuda/gather.cu
+++ b/testing/cuda/gather.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 #include <algorithm>
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__
 void gather_kernel(ExecutionPolicy exec, Iterator1 map_first, Iterator1 map_last, Iterator2 elements_first, Iterator3 result)
@@ -87,7 +87,7 @@ void TestGatherCudaStreams()
 DECLARE_UNITTEST(TestGatherCudaStreams);
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Predicate>
 __global__
 void gather_if_kernel(ExecutionPolicy exec, Iterator1 map_first, Iterator1 map_last, Iterator2 stencil_first, Iterator3 elements_first, Iterator4 result, Predicate pred)

--- a/testing/cuda/gather.cu
+++ b/testing/cuda/gather.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 #include <algorithm>
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__
 void gather_kernel(ExecutionPolicy exec, Iterator1 map_first, Iterator1 map_last, Iterator2 elements_first, Iterator3 result)
@@ -56,6 +57,7 @@ void TestGatherDeviceDevice(const size_t n)
   TestGatherDevice<T>(thrust::device, n);
 }
 DECLARE_VARIABLE_UNITTEST(TestGatherDeviceDevice);
+#endif
 
 
 void TestGatherCudaStreams()
@@ -85,6 +87,7 @@ void TestGatherCudaStreams()
 DECLARE_UNITTEST(TestGatherCudaStreams);
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Predicate>
 __global__
 void gather_if_kernel(ExecutionPolicy exec, Iterator1 map_first, Iterator1 map_last, Iterator2 stencil_first, Iterator3 elements_first, Iterator4 result, Predicate pred)
@@ -157,6 +160,7 @@ void TestGatherIfDeviceDevice(const size_t n)
   TestGatherIfDevice<T>(thrust::device, n);
 }
 DECLARE_VARIABLE_UNITTEST(TestGatherIfDeviceDevice);
+#endif
 
 void TestGatherIfCudaStreams(void)
 {

--- a/testing/cuda/generate.cu
+++ b/testing/cuda/generate.cu
@@ -16,7 +16,7 @@ struct return_value
 };
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Function>
 __global__
 void generate_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f)
@@ -88,7 +88,7 @@ void TestGenerateCudaStreams()
 DECLARE_UNITTEST(TestGenerateCudaStreams);
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Size, typename Function>
 __global__
 void generate_n_kernel(ExecutionPolicy exec, Iterator first, Size n, Function f)

--- a/testing/cuda/generate.cu
+++ b/testing/cuda/generate.cu
@@ -3,14 +3,6 @@
 #include <thrust/execution_policy.h>
 
 
-template<typename ExecutionPolicy, typename Iterator, typename Function>
-__global__
-void generate_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f)
-{
-  thrust::generate(exec, first, last, f);
-}
-
-
 template<typename T>
 struct return_value
 {
@@ -22,6 +14,15 @@ struct return_value
   __host__ __device__
   T operator()(void){ return val; }
 };
+
+
+#if THRUST_TEST_DEVICE_SIDE
+template<typename ExecutionPolicy, typename Iterator, typename Function>
+__global__
+void generate_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f)
+{
+  thrust::generate(exec, first, last, f);
+}
 
 
 template<typename T, typename ExecutionPolicy>
@@ -59,6 +60,7 @@ void TestGenerateDeviceDevice(const size_t n)
   TestGenerateDevice<T>(thrust::device, n);
 }
 DECLARE_VARIABLE_UNITTEST(TestGenerateDeviceDevice);
+#endif
 
 
 void TestGenerateCudaStreams()
@@ -86,6 +88,7 @@ void TestGenerateCudaStreams()
 DECLARE_UNITTEST(TestGenerateCudaStreams);
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Size, typename Function>
 __global__
 void generate_n_kernel(ExecutionPolicy exec, Iterator first, Size n, Function f)
@@ -129,6 +132,7 @@ void TestGenerateNDeviceDevice(const size_t n)
   TestGenerateNDevice<T>(thrust::device, n);
 }
 DECLARE_VARIABLE_UNITTEST(TestGenerateNDeviceDevice);
+#endif
 
 
 void TestGenerateNCudaStreams()

--- a/testing/cuda/inner_product.cu
+++ b/testing/cuda/inner_product.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename T, typename Iterator3>
 __global__
 void inner_product_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, T init, Iterator3 result)

--- a/testing/cuda/inner_product.cu
+++ b/testing/cuda/inner_product.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename T, typename Iterator3>
 __global__
 void inner_product_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, T init, Iterator3 result)
@@ -50,6 +51,7 @@ void TestInnerProductDeviceDevice()
   TestInnerProductDevice(thrust::device);
 };
 DECLARE_UNITTEST(TestInnerProductDeviceDevice);
+#endif
 
 
 void TestInnerProductCudaStreams()

--- a/testing/cuda/is_partitioned.cu
+++ b/testing/cuda/is_partitioned.cu
@@ -4,7 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Predicate, typename Iterator2>
 __global__
 void is_partitioned_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Predicate pred, Iterator2 result)

--- a/testing/cuda/is_partitioned.cu
+++ b/testing/cuda/is_partitioned.cu
@@ -4,6 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Predicate, typename Iterator2>
 __global__
 void is_partitioned_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Predicate pred, Iterator2 result)
@@ -66,6 +67,7 @@ void TestIsPartitionedDeviceDevice()
   TestIsPartitionedDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestIsPartitionedDeviceDevice);
+#endif
 
 
 void TestIsPartitionedCudaStreams()

--- a/testing/cuda/is_sorted.cu
+++ b/testing/cuda/is_sorted.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Iterator2>
 __global__
 void is_sorted_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Iterator2 result)

--- a/testing/cuda/is_sorted.cu
+++ b/testing/cuda/is_sorted.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Iterator2>
 __global__
 void is_sorted_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Iterator2 result)
@@ -55,6 +56,7 @@ void TestIsSortedDeviceDevice()
   TestIsSortedDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestIsSortedDeviceDevice);
+#endif
 
 
 void TestIsSortedCudaStreams()

--- a/testing/cuda/is_sorted_until.cu
+++ b/testing/cuda/is_sorted_until.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void is_sorted_until_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)
@@ -57,6 +58,7 @@ void TestIsSortedUntilDeviceDevice()
   TestIsSortedUntilDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestIsSortedUntilDeviceDevice);
+#endif
 
 
 void TestIsSortedUntilCudaStreams()

--- a/testing/cuda/is_sorted_until.cu
+++ b/testing/cuda/is_sorted_until.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void is_sorted_until_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)

--- a/testing/cuda/logical.cu
+++ b/testing/cuda/logical.cu
@@ -4,7 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Function, typename Iterator2>
 __global__
 void all_of_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f, Iterator2 result)
@@ -113,7 +113,7 @@ void TestAllOfCudaStreams()
 DECLARE_UNITTEST(TestAllOfCudaStreams);
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Function, typename Iterator2>
 __global__
 void any_of_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f, Iterator2 result)
@@ -223,7 +223,7 @@ void TestAnyOfCudaStreams()
 DECLARE_UNITTEST(TestAnyOfCudaStreams);
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Function, typename Iterator2>
 __global__
 void none_of_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f, Iterator2 result)

--- a/testing/cuda/logical.cu
+++ b/testing/cuda/logical.cu
@@ -4,6 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Function, typename Iterator2>
 __global__
 void all_of_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f, Iterator2 result)
@@ -83,6 +84,7 @@ void TestAllOfDeviceDevice()
   TestAllOfDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestAllOfDeviceDevice);
+#endif
 
 
 void TestAllOfCudaStreams()
@@ -111,6 +113,7 @@ void TestAllOfCudaStreams()
 DECLARE_UNITTEST(TestAllOfCudaStreams);
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Function, typename Iterator2>
 __global__
 void any_of_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f, Iterator2 result)
@@ -191,6 +194,7 @@ void TestAnyOfDeviceDevice()
   TestAnyOfDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestAnyOfDeviceDevice);
+#endif
 
 
 void TestAnyOfCudaStreams()
@@ -219,6 +223,7 @@ void TestAnyOfCudaStreams()
 DECLARE_UNITTEST(TestAnyOfCudaStreams);
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Function, typename Iterator2>
 __global__
 void none_of_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f, Iterator2 result)
@@ -299,6 +304,7 @@ void TestNoneOfDeviceDevice()
   TestNoneOfDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestNoneOfDeviceDevice);
+#endif
 
 
 void TestNoneOfCudaStreams()

--- a/testing/cuda/max_element.cu
+++ b/testing/cuda/max_element.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Iterator2>
 __global__
 void max_element_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Iterator2 result)
@@ -72,6 +73,7 @@ void TestMaxElementDeviceNoSync()
   TestMaxElementDevice(thrust::cuda::par_nosync);
 }
 DECLARE_UNITTEST(TestMaxElementDeviceNoSync);
+#endif
 
 
 template<typename ExecutionPolicy>

--- a/testing/cuda/max_element.cu
+++ b/testing/cuda/max_element.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Iterator2>
 __global__
 void max_element_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Iterator2 result)

--- a/testing/cuda/memory.cu
+++ b/testing/cuda/memory.cu
@@ -35,7 +35,7 @@ void TestSelectSystemCudaToCpp()
 DECLARE_UNITTEST(TestSelectSystemCudaToCpp);
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename Iterator>
 __global__ void get_temporary_buffer_kernel(size_t n, Iterator result)
 {

--- a/testing/cuda/memory.cu
+++ b/testing/cuda/memory.cu
@@ -35,6 +35,7 @@ void TestSelectSystemCudaToCpp()
 DECLARE_UNITTEST(TestSelectSystemCudaToCpp);
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename Iterator>
 __global__ void get_temporary_buffer_kernel(size_t n, Iterator result)
 {
@@ -132,4 +133,5 @@ void TestMallocDeviceSeq()
   }
 }
 DECLARE_UNITTEST(TestMallocDeviceSeq);
+#endif
 

--- a/testing/cuda/merge.cu
+++ b/testing/cuda/merge.cu
@@ -6,7 +6,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
 __global__
 void merge_kernel(ExecutionPolicy exec,

--- a/testing/cuda/merge.cu
+++ b/testing/cuda/merge.cu
@@ -6,6 +6,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
 __global__
 void merge_kernel(ExecutionPolicy exec,
@@ -80,6 +81,7 @@ void TestMergeDeviceDevice()
   TestMergeDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestMergeDeviceDevice);
+#endif
 
 
 void TestMergeCudaStreams()

--- a/testing/cuda/merge_by_key.cu
+++ b/testing/cuda/merge_by_key.cu
@@ -5,7 +5,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy,
          typename Iterator1,
          typename Iterator2,

--- a/testing/cuda/merge_by_key.cu
+++ b/testing/cuda/merge_by_key.cu
@@ -5,6 +5,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy,
          typename Iterator1,
          typename Iterator2,
@@ -84,6 +85,7 @@ void TestMergeByKeyDeviceDevice()
   TestMergeByKeyDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestMergeByKeyDeviceDevice);
+#endif
 
 
 void TestMergeByKeyCudaStreams()

--- a/testing/cuda/min_element.cu
+++ b/testing/cuda/min_element.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Iterator2>
 __global__
 void min_element_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Iterator2 result)

--- a/testing/cuda/min_element.cu
+++ b/testing/cuda/min_element.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Iterator2>
 __global__
 void min_element_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Iterator2 result)
@@ -64,6 +65,7 @@ void TestMinElementDeviceDevice()
   TestMinElementDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestMinElementDeviceDevice);
+#endif
 
 
 void TestMinElementCudaStreams()

--- a/testing/cuda/minmax_element.cu
+++ b/testing/cuda/minmax_element.cu
@@ -2,7 +2,7 @@
 #include <thrust/extrema.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void minmax_element_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)

--- a/testing/cuda/minmax_element.cu
+++ b/testing/cuda/minmax_element.cu
@@ -2,6 +2,7 @@
 #include <thrust/extrema.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void minmax_element_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)
@@ -85,6 +86,7 @@ void TestMinMaxElementDeviceDevice()
   TestMinMaxElementDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestMinMaxElementDeviceDevice);
+#endif
 
 
 void TestMinMaxElementCudaStreams()

--- a/testing/cuda/mismatch.cu
+++ b/testing/cuda/mismatch.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__ void mismatch_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator3 result)
 {
@@ -72,6 +73,7 @@ void TestMismatchDeviceDevice()
   TestMismatchDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestMismatchDeviceDevice);
+#endif
 
 
 void TestMismatchCudaStreams()

--- a/testing/cuda/mismatch.cu
+++ b/testing/cuda/mismatch.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__ void mismatch_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator3 result)
 {

--- a/testing/cuda/pair_sort.cu
+++ b/testing/cuda/pair_sort.cu
@@ -4,6 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator>
 __global__
 void stable_sort_kernel(ExecutionPolicy exec, Iterator first, Iterator last)
@@ -61,4 +62,5 @@ void TestPairStableSortDeviceDevice()
   TestPairStableSortDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestPairStableSortDeviceDevice);
+#endif
 

--- a/testing/cuda/pair_sort.cu
+++ b/testing/cuda/pair_sort.cu
@@ -4,7 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator>
 __global__
 void stable_sort_kernel(ExecutionPolicy exec, Iterator first, Iterator last)

--- a/testing/cuda/pair_sort_by_key.cu
+++ b/testing/cuda/pair_sort_by_key.cu
@@ -6,6 +6,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void stable_sort_by_key_kernel(ExecutionPolicy exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 values_first)
@@ -71,4 +72,5 @@ void TestPairStableSortByKeyDeviceDevice()
   TestPairStableSortByKeyDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestPairStableSortByKeyDeviceDevice);
+#endif
 

--- a/testing/cuda/pair_sort_by_key.cu
+++ b/testing/cuda/pair_sort_by_key.cu
@@ -6,7 +6,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void stable_sort_by_key_kernel(ExecutionPolicy exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 values_first)

--- a/testing/cuda/partition.cu
+++ b/testing/cuda/partition.cu
@@ -12,7 +12,7 @@ struct is_even
 };
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Predicate, typename Iterator2>
 __global__
 void partition_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Predicate pred, Iterator2 result)

--- a/testing/cuda/partition.cu
+++ b/testing/cuda/partition.cu
@@ -4,20 +4,21 @@
 #include <thrust/execution_policy.h>
 
 
-template<typename ExecutionPolicy, typename Iterator1, typename Predicate, typename Iterator2>
-__global__
-void partition_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Predicate pred, Iterator2 result)
-{
-  *result = thrust::partition(exec, first, last, pred);
-}
-
-
 template<typename T>
 struct is_even
 {
   __host__ __device__
   bool operator()(T x) const { return ((int) x % 2) == 0; }
 };
+
+
+#if THRUST_TEST_DEVICE_SIDE
+template<typename ExecutionPolicy, typename Iterator1, typename Predicate, typename Iterator2>
+__global__
+void partition_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Predicate pred, Iterator2 result)
+{
+  *result = thrust::partition(exec, first, last, pred);
+}
 
 
 template<typename ExecutionPolicy>
@@ -558,6 +559,7 @@ void TestStablePartitionCopyStencilDeviceNoSync()
   TestStablePartitionCopyStencilDevice(thrust::cuda::par_nosync);
 }
 DECLARE_UNITTEST(TestStablePartitionCopyStencilDeviceNoSync);
+#endif
 
 
 template<typename ExecutionPolicy>

--- a/testing/cuda/partition_point.cu
+++ b/testing/cuda/partition_point.cu
@@ -4,7 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Predicate, typename Iterator2>
 __global__
 void partition_point_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Predicate pred, Iterator2 result)

--- a/testing/cuda/partition_point.cu
+++ b/testing/cuda/partition_point.cu
@@ -4,6 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Predicate, typename Iterator2>
 __global__
 void partition_point_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Predicate pred, Iterator2 result)
@@ -50,6 +51,7 @@ void TestPartitionPointDeviceDevice()
   TestPartitionPointDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestPartitionPointDeviceDevice);
+#endif
 
 
 void TestPartitionPointCudaStreams()

--- a/testing/cuda/reduce.cu
+++ b/testing/cuda/reduce.cu
@@ -4,7 +4,7 @@
 #include <thrust/iterator/constant_iterator.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T, typename Iterator2>
 __global__
 void reduce_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T init, Iterator2 result)

--- a/testing/cuda/reduce.cu
+++ b/testing/cuda/reduce.cu
@@ -4,6 +4,7 @@
 #include <thrust/iterator/constant_iterator.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T, typename Iterator2>
 __global__
 void reduce_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T init, Iterator2 result)
@@ -63,6 +64,7 @@ struct TestReduceDeviceNoSync
   }
 };
 VariableUnitTest<TestReduceDeviceNoSync, IntegralTypes> TestReduceDeviceNoSyncInstance;
+#endif
 
 
 template<typename ExecutionPolicy>

--- a/testing/cuda/reduce_by_key.cu
+++ b/testing/cuda/reduce_by_key.cu
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Iterator5>
 __global__
 void reduce_by_key_kernel(ExecutionPolicy exec,
@@ -48,6 +49,7 @@ void reduce_by_key_kernel(ExecutionPolicy exec,
 {
   *result = thrust::reduce_by_key(exec, keys_first, keys_last, values_first, keys_result, values_result, pred, binary_op);
 }
+#endif
 
 
 template<typename T>
@@ -90,6 +92,7 @@ void initialize_values(Vector& values)
 }
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy>
 void TestReduceByKeyDevice(ExecutionPolicy exec)
 {
@@ -201,6 +204,7 @@ void TestReduceByKeyDeviceNoSync()
   TestReduceByKeyDevice(thrust::cuda::par_nosync);
 }
 DECLARE_UNITTEST(TestReduceByKeyDeviceNoSync);
+#endif
 
 
 template<typename ExecutionPolicy>

--- a/testing/cuda/reduce_by_key.cu
+++ b/testing/cuda/reduce_by_key.cu
@@ -8,7 +8,7 @@
 #include <cstdint>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Iterator5>
 __global__
 void reduce_by_key_kernel(ExecutionPolicy exec,
@@ -92,7 +92,7 @@ void initialize_values(Vector& values)
 }
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy>
 void TestReduceByKeyDevice(ExecutionPolicy exec)
 {

--- a/testing/cuda/remove.cu
+++ b/testing/cuda/remove.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T, typename Iterator2>
 __global__
 void remove_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T val, Iterator2 result)
@@ -71,7 +71,7 @@ struct is_true
 };
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy>
 void TestRemoveDevice(ExecutionPolicy exec)
 {

--- a/testing/cuda/remove.cu
+++ b/testing/cuda/remove.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T, typename Iterator2>
 __global__
 void remove_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T val, Iterator2 result)
@@ -49,6 +50,7 @@ void remove_copy_if_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last
 {
   *result_end = thrust::remove_copy_if(exec, first, last, stencil_first, result, pred);
 }
+#endif
 
 
 template<typename T>
@@ -69,6 +71,7 @@ struct is_true
 };
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy>
 void TestRemoveDevice(ExecutionPolicy exec)
 {
@@ -328,6 +331,7 @@ void TestRemoveCopyIfStencilDeviceDevice()
   TestRemoveCopyIfStencilDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestRemoveCopyIfStencilDeviceDevice);
+#endif
 
 
 void TestRemoveCudaStreams()

--- a/testing/cuda/replace.cu
+++ b/testing/cuda/replace.cu
@@ -10,7 +10,7 @@ struct less_than_five
 };
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T1, typename T2>
 __global__
 void replace_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T1 old_value, T2 new_value)

--- a/testing/cuda/replace.cu
+++ b/testing/cuda/replace.cu
@@ -10,6 +10,7 @@ struct less_than_five
 };
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T1, typename T2>
 __global__
 void replace_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T1 old_value, T2 new_value)
@@ -258,6 +259,7 @@ void TestReplaceCopyIfStencilDeviceDevice()
   TestReplaceCopyIfStencilDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestReplaceCopyIfStencilDeviceDevice);
+#endif
 
 
 void TestReplaceCudaStreams()

--- a/testing/cuda/reverse.cu
+++ b/testing/cuda/reverse.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator>
 __global__
 void reverse_kernel(ExecutionPolicy exec, Iterator first, Iterator last)
@@ -82,6 +83,7 @@ void TestReverseCopyDeviceDevice()
   TestReverseCopyDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestReverseCopyDeviceDevice);
+#endif
 
 
 void TestReverseCudaStreams()

--- a/testing/cuda/reverse.cu
+++ b/testing/cuda/reverse.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator>
 __global__
 void reverse_kernel(ExecutionPolicy exec, Iterator first, Iterator last)

--- a/testing/cuda/scan.cu
+++ b/testing/cuda/scan.cu
@@ -4,7 +4,7 @@
 #include <thrust/functional.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void inclusive_scan_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)

--- a/testing/cuda/scan.cu
+++ b/testing/cuda/scan.cu
@@ -4,6 +4,7 @@
 #include <thrust/functional.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void inclusive_scan_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)
@@ -116,6 +117,7 @@ struct TestScanDeviceDevice
   }
 };
 VariableUnitTest<TestScanDeviceDevice, IntegralTypes> TestScanDeviceDeviceInstance;
+#endif
 
 
 void TestScanCudaStreams()

--- a/testing/cuda/scan_by_key.cu
+++ b/testing/cuda/scan_by_key.cu
@@ -4,6 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__
 void inclusive_scan_by_key_kernel(ExecutionPolicy exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 values_first, Iterator3 result)
@@ -131,6 +132,7 @@ void TestScanByKeyDeviceDevice()
   TestScanByKeyDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestScanByKeyDeviceDevice);
+#endif
 
 
 void TestInclusiveScanByKeyCudaStreams()

--- a/testing/cuda/scan_by_key.cu
+++ b/testing/cuda/scan_by_key.cu
@@ -4,7 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__
 void inclusive_scan_by_key_kernel(ExecutionPolicy exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 values_first, Iterator3 result)

--- a/testing/cuda/scatter.cu
+++ b/testing/cuda/scatter.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 #include <algorithm>
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__
 void scatter_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 map_first, Iterator3 result)
@@ -112,6 +113,7 @@ void TestScatterIfDeviceDevice()
   TestScatterIfDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestScatterIfDeviceDevice);
+#endif
 
 
 void TestScatterCudaStreams()

--- a/testing/cuda/scatter.cu
+++ b/testing/cuda/scatter.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 #include <algorithm>
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__
 void scatter_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 map_first, Iterator3 result)

--- a/testing/cuda/sequence.cu
+++ b/testing/cuda/sequence.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator>
 __global__
 void sequence_kernel(ExecutionPolicy exec, Iterator first, Iterator last)
@@ -80,6 +81,7 @@ void TestSequenceDeviceDevice()
   TestSequenceDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestSequenceDeviceDevice);
+#endif
 
 void TestSequenceCudaStreams()
 {

--- a/testing/cuda/sequence.cu
+++ b/testing/cuda/sequence.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator>
 __global__
 void sequence_kernel(ExecutionPolicy exec, Iterator first, Iterator last)

--- a/testing/cuda/set_difference.cu
+++ b/testing/cuda/set_difference.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
 __global__
 void set_difference_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 result1, Iterator4 result2)

--- a/testing/cuda/set_difference.cu
+++ b/testing/cuda/set_difference.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
 __global__
 void set_difference_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 result1, Iterator4 result2)
@@ -52,6 +53,7 @@ void TestSetDifferenceDeviceDevice()
   TestSetDifferenceDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestSetDifferenceDeviceDevice);
+#endif
 
 
 void TestSetDifferenceCudaStreams()

--- a/testing/cuda/set_difference_by_key.cu
+++ b/testing/cuda/set_difference_by_key.cu
@@ -4,7 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Iterator5, typename Iterator6, typename Iterator7>
 __global__
 void set_difference_by_key_kernel(ExecutionPolicy exec,

--- a/testing/cuda/set_difference_by_key.cu
+++ b/testing/cuda/set_difference_by_key.cu
@@ -4,6 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Iterator5, typename Iterator6, typename Iterator7>
 __global__
 void set_difference_by_key_kernel(ExecutionPolicy exec,
@@ -82,6 +83,7 @@ void TestSetDifferenceByKeyDeviceDevice()
   TestSetDifferenceByKeyDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestSetDifferenceByKeyDeviceDevice);
+#endif
 
 
 void TestSetDifferenceByKeyCudaStreams()

--- a/testing/cuda/set_intersection.cu
+++ b/testing/cuda/set_intersection.cu
@@ -6,6 +6,7 @@
 #include <thrust/iterator/discard_iterator.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
 __global__
 void set_intersection_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1,
@@ -64,6 +65,7 @@ void TestSetIntersectionDeviceNoSync()
   TestSetIntersectionDevice(thrust::cuda::par_nosync);
 }
 DECLARE_UNITTEST(TestSetIntersectionDeviceNoSync);
+#endif
 
 
 template<typename ExecutionPolicy>

--- a/testing/cuda/set_intersection.cu
+++ b/testing/cuda/set_intersection.cu
@@ -6,7 +6,7 @@
 #include <thrust/iterator/discard_iterator.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
 __global__
 void set_intersection_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1,

--- a/testing/cuda/set_intersection_by_key.cu
+++ b/testing/cuda/set_intersection_by_key.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Iterator5, typename Iterator6>
 __global__
 void set_intersection_by_key_kernel(ExecutionPolicy exec,

--- a/testing/cuda/set_intersection_by_key.cu
+++ b/testing/cuda/set_intersection_by_key.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Iterator5, typename Iterator6>
 __global__
 void set_intersection_by_key_kernel(ExecutionPolicy exec,
@@ -78,6 +79,7 @@ void TestSetIntersectionByKeyDeviceNoSync()
   TestSetIntersectionByKeyDevice(thrust::cuda::par_nosync);
 }
 DECLARE_UNITTEST(TestSetIntersectionByKeyDeviceNoSync);
+#endif
 
 
 template<typename ExecutionPolicy>

--- a/testing/cuda/set_symmetric_difference.cu
+++ b/testing/cuda/set_symmetric_difference.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
 __global__
 void set_symmetric_difference_kernel(ExecutionPolicy exec,

--- a/testing/cuda/set_symmetric_difference.cu
+++ b/testing/cuda/set_symmetric_difference.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
 __global__
 void set_symmetric_difference_kernel(ExecutionPolicy exec,
@@ -59,6 +60,7 @@ void TestSetSymmetricDifferenceDeviceDevice()
   TestSetSymmetricDifferenceDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestSetSymmetricDifferenceDeviceDevice);
+#endif
 
 
 void TestSetSymmetricDifferenceCudaStreams()

--- a/testing/cuda/set_symmetric_difference_by_key.cu
+++ b/testing/cuda/set_symmetric_difference_by_key.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Iterator5, typename Iterator6, typename Iterator7>
 __global__
 void set_symmetric_difference_by_key_kernel(ExecutionPolicy exec,

--- a/testing/cuda/set_symmetric_difference_by_key.cu
+++ b/testing/cuda/set_symmetric_difference_by_key.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Iterator5, typename Iterator6, typename Iterator7>
 __global__
 void set_symmetric_difference_by_key_kernel(ExecutionPolicy exec,
@@ -74,6 +75,7 @@ void TestSetSymmetricDifferenceByKeyDeviceDevice()
   TestSetSymmetricDifferenceByKeyDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestSetSymmetricDifferenceByKeyDeviceDevice);
+#endif
 
 
 void TestSetSymmetricDifferenceByKeyCudaStreams()

--- a/testing/cuda/set_union.cu
+++ b/testing/cuda/set_union.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
 __global__
 void set_union_kernel(ExecutionPolicy exec,

--- a/testing/cuda/set_union.cu
+++ b/testing/cuda/set_union.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
 __global__
 void set_union_kernel(ExecutionPolicy exec,
@@ -59,6 +60,7 @@ void TestSetUnionDeviceDevice()
   TestSetUnionDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestSetUnionDeviceDevice);
+#endif
 
 
 void TestSetUnionCudaStreams()

--- a/testing/cuda/set_union_by_key.cu
+++ b/testing/cuda/set_union_by_key.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Iterator5, typename Iterator6, typename Iterator7>
 __global__
 void set_union_by_key_kernel(ExecutionPolicy exec,
@@ -73,6 +74,7 @@ void TestSetUnionByKeyDeviceDevice()
   TestSetUnionByKeyDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestSetUnionByKeyDeviceDevice);
+#endif
 
 
 void TestSetUnionByKeyCudaStreams()

--- a/testing/cuda/set_union_by_key.cu
+++ b/testing/cuda/set_union_by_key.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Iterator5, typename Iterator6, typename Iterator7>
 __global__
 void set_union_by_key_kernel(ExecutionPolicy exec,

--- a/testing/cuda/sort.cu
+++ b/testing/cuda/sort.cu
@@ -4,14 +4,6 @@
 #include <thrust/execution_policy.h>
 
 
-template<typename ExecutionPolicy, typename Iterator, typename Compare>
-__global__
-void sort_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Compare comp)
-{
-  thrust::sort(exec, first, last, comp);
-}
-
-
 template<typename T>
 struct my_less
 {
@@ -21,6 +13,15 @@ struct my_less
     return lhs < rhs;
   }
 };
+
+
+#if THRUST_TEST_DEVICE_SIDE
+template<typename ExecutionPolicy, typename Iterator, typename Compare>
+__global__
+void sort_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Compare comp)
+{
+  thrust::sort(exec, first, last, comp);
+}
 
 
 template<typename T, typename ExecutionPolicy, typename Compare>
@@ -101,6 +102,7 @@ VariableUnitTest<
   TestSortDeviceDevice,
   unittest::type_list<unittest::int8_t,unittest::int32_t>
 > TestSortDeviceDeviceInstance;
+#endif
 
 
 void TestSortCudaStreams()

--- a/testing/cuda/sort.cu
+++ b/testing/cuda/sort.cu
@@ -15,7 +15,7 @@ struct my_less
 };
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Compare>
 __global__
 void sort_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Compare comp)

--- a/testing/cuda/sort_by_key.cu
+++ b/testing/cuda/sort_by_key.cu
@@ -15,7 +15,7 @@ struct my_less
 };
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Compare>
 __global__
 void sort_by_key_kernel(ExecutionPolicy exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 values_first, Compare comp)

--- a/testing/cuda/sort_by_key.cu
+++ b/testing/cuda/sort_by_key.cu
@@ -4,14 +4,6 @@
 #include <thrust/functional.h>
 
 
-template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Compare>
-__global__
-void sort_by_key_kernel(ExecutionPolicy exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 values_first, Compare comp)
-{
-  thrust::sort_by_key(exec, keys_first, keys_last, values_first, comp);
-}
-
-
 template<typename T>
 struct my_less
 {
@@ -21,6 +13,15 @@ struct my_less
     return lhs < rhs;
   }
 };
+
+
+#if THRUST_TEST_DEVICE_SIDE
+template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Compare>
+__global__
+void sort_by_key_kernel(ExecutionPolicy exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 values_first, Compare comp)
+{
+  thrust::sort_by_key(exec, keys_first, keys_last, values_first, comp);
+}
 
 
 template<typename T, typename ExecutionPolicy, typename Compare>
@@ -104,6 +105,7 @@ VariableUnitTest<
   TestSortByKeyDeviceDevice,
   unittest::type_list<unittest::int8_t,unittest::int32_t>
 > TestSortByKeyDeviceDeviceInstance;
+#endif
 
 
 void TestComparisonSortByKeyCudaStreams()

--- a/testing/cuda/swap_ranges.cu
+++ b/testing/cuda/swap_ranges.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void swap_ranges_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1, Iterator2 first2)
@@ -50,6 +51,7 @@ void TestSwapRangesDeviceDevice()
   TestSwapRangesDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestSwapRangesDeviceDevice);
+#endif
 
 void TestSwapRangesCudaStreams()
 {

--- a/testing/cuda/swap_ranges.cu
+++ b/testing/cuda/swap_ranges.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void swap_ranges_kernel(ExecutionPolicy exec, Iterator1 first1, Iterator1 last1, Iterator2 first2)

--- a/testing/cuda/tabulate.cu
+++ b/testing/cuda/tabulate.cu
@@ -4,7 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Function>
 __global__
 void tabulate_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f)

--- a/testing/cuda/tabulate.cu
+++ b/testing/cuda/tabulate.cu
@@ -4,6 +4,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename Function>
 __global__
 void tabulate_kernel(ExecutionPolicy exec, Iterator first, Iterator last, Function f)
@@ -69,6 +70,7 @@ void TestTabulateDeviceDevice()
   TestTabulateDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestTabulateDeviceDevice);
+#endif
 
 void TestTabulateCudaStreams()
 {

--- a/testing/cuda/transform.cu
+++ b/testing/cuda/transform.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Function, typename Iterator3>
 __global__
 void transform_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result1, Function f, Iterator3 result2)
@@ -270,6 +271,7 @@ void TestTransformIfBinaryDeviceDevice()
   TestTransformIfBinaryDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestTransformIfBinaryDeviceDevice);
+#endif
 
 void TestTransformUnaryCudaStreams()
 {

--- a/testing/cuda/transform.cu
+++ b/testing/cuda/transform.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Function, typename Iterator3>
 __global__
 void transform_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result1, Function f, Iterator3 result2)

--- a/testing/cuda/transform_reduce.cu
+++ b/testing/cuda/transform_reduce.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Function1, typename T, typename Function2, typename Iterator2>
 __global__
 void transform_reduce_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Function1 f1, T init, Function2 f2, Iterator2 result)

--- a/testing/cuda/transform_reduce.cu
+++ b/testing/cuda/transform_reduce.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Function1, typename T, typename Function2, typename Iterator2>
 __global__
 void transform_reduce_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Function1 f1, T init, Function2 f2, Iterator2 result)
@@ -44,6 +45,7 @@ void TestTransformReduceDeviceDevice()
   TestTransformReduceDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestTransformReduceDeviceDevice);
+#endif
 
 
 void TestTransformReduceCudaStreams()

--- a/testing/cuda/transform_scan.cu
+++ b/testing/cuda/transform_scan.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Function1, typename Function2, typename Iterator3>
 __global__
 void transform_inclusive_scan_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result1, Function1 f1, Function2 f2, Iterator3 result2)

--- a/testing/cuda/transform_scan.cu
+++ b/testing/cuda/transform_scan.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Function1, typename Function2, typename Iterator3>
 __global__
 void transform_inclusive_scan_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result1, Function1 f1, Function2 f2, Iterator3 result2)
@@ -115,6 +116,7 @@ void TestTransformScanDeviceDevice()
   TestTransformScanDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestTransformScanDeviceDevice);
+#endif
 
 
 void TestTransformScanCudaStreams()

--- a/testing/cuda/uninitialized_copy.cu
+++ b/testing/cuda/uninitialized_copy.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void uninitialized_copy_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)
@@ -76,7 +76,7 @@ void TestUninitializedCopyCudaStreams()
 DECLARE_UNITTEST(TestUninitializedCopyCudaStreams);
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Size, typename Iterator2>
 __global__
 void uninitialized_copy_n_kernel(ExecutionPolicy exec, Iterator1 first, Size n, Iterator2 result)

--- a/testing/cuda/uninitialized_copy.cu
+++ b/testing/cuda/uninitialized_copy.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void uninitialized_copy_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)
@@ -45,6 +46,7 @@ void TestUninitializedCopyDeviceDevice()
   TestUninitializedCopyDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestUninitializedCopyDeviceDevice);
+#endif
 
 
 void TestUninitializedCopyCudaStreams()
@@ -74,6 +76,7 @@ void TestUninitializedCopyCudaStreams()
 DECLARE_UNITTEST(TestUninitializedCopyCudaStreams);
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Size, typename Iterator2>
 __global__
 void uninitialized_copy_n_kernel(ExecutionPolicy exec, Iterator1 first, Size n, Iterator2 result)
@@ -116,6 +119,7 @@ void TestUninitializedCopyNDeviceDevice()
   TestUninitializedCopyNDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestUninitializedCopyNDeviceDevice);
+#endif
 
 
 void TestUninitializedCopyNCudaStreams()

--- a/testing/cuda/uninitialized_fill.cu
+++ b/testing/cuda/uninitialized_fill.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T>
 __global__
 void uninitialized_fill_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T val)
@@ -121,7 +121,7 @@ void TestUninitializedFillCudaStreams()
 DECLARE_UNITTEST(TestUninitializedFillCudaStreams);
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Size, typename T, typename Iterator2>
 __global__
 void uninitialized_fill_n_kernel(ExecutionPolicy exec, Iterator1 first, Size n, T val, Iterator2 result)

--- a/testing/cuda/uninitialized_fill.cu
+++ b/testing/cuda/uninitialized_fill.cu
@@ -3,6 +3,7 @@
 #include <thrust/execution_policy.h>
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator, typename T>
 __global__
 void uninitialized_fill_kernel(ExecutionPolicy exec, Iterator first, Iterator last, T val)
@@ -90,6 +91,7 @@ void TestUninitializedFillDeviceDevice()
   TestUninitializedFillDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestUninitializedFillDeviceDevice);
+#endif
 
 
 void TestUninitializedFillCudaStreams()
@@ -119,6 +121,7 @@ void TestUninitializedFillCudaStreams()
 DECLARE_UNITTEST(TestUninitializedFillCudaStreams);
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Size, typename T, typename Iterator2>
 __global__
 void uninitialized_fill_n_kernel(ExecutionPolicy exec, Iterator1 first, Size n, T val, Iterator2 result)
@@ -220,6 +223,7 @@ void TestUninitializedFillNDeviceDevice()
   TestUninitializedFillNDevice(thrust::device);
 }
 DECLARE_UNITTEST(TestUninitializedFillNDeviceDevice);
+#endif
 
 
 void TestUninitializedFillNCudaStreams()

--- a/testing/cuda/unique.cu
+++ b/testing/cuda/unique.cu
@@ -3,6 +3,15 @@
 #include <thrust/execution_policy.h>
 
 
+template<typename T>
+struct is_equal_div_10_unique
+{
+  __host__ __device__
+  bool operator()(const T x, const T& y) const { return ((int) x / 10) == ((int) y / 10); }
+};
+
+
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void unique_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)
@@ -17,14 +26,6 @@ void unique_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Binary
 {
   *result = thrust::unique(exec, first, last, pred);
 }
-
-
-template<typename T>
-struct is_equal_div_10_unique
-{
-  __host__ __device__
-  bool operator()(const T x, const T& y) const { return ((int) x / 10) == ((int) y / 10); }
-};
 
 
 template<typename ExecutionPolicy>
@@ -99,6 +100,7 @@ void TestUniqueDeviceNoSync()
   TestUniqueDevice(thrust::cuda::par_nosync);
 }
 DECLARE_UNITTEST(TestUniqueDeviceNoSync);
+#endif
 
 
 template<typename ExecutionPolicy>
@@ -164,6 +166,7 @@ void TestUniqueCudaStreamsNoSync()
 DECLARE_UNITTEST(TestUniqueCudaStreamsNoSync);
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__
 void unique_copy_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result1, Iterator3 result2)
@@ -254,6 +257,7 @@ void TestUniqueCopyDeviceNoSync()
   TestUniqueCopyDevice(thrust::cuda::par_nosync);
 }
 DECLARE_UNITTEST(TestUniqueCopyDeviceNoSync);
+#endif
 
 
 template<typename ExecutionPolicy>
@@ -321,6 +325,7 @@ void TestUniqueCopyCudaStreamsNoSync()
 DECLARE_UNITTEST(TestUniqueCopyCudaStreamsNoSync);
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void unique_count_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)
@@ -394,6 +399,7 @@ void TestUniqueCountDeviceNoSync()
   TestUniqueCountDevice(thrust::cuda::par_nosync);
 }
 DECLARE_UNITTEST(TestUniqueCountDeviceNoSync);
+#endif
 
 
 template<typename ExecutionPolicy>

--- a/testing/cuda/unique.cu
+++ b/testing/cuda/unique.cu
@@ -11,7 +11,7 @@ struct is_equal_div_10_unique
 };
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void unique_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)
@@ -166,7 +166,7 @@ void TestUniqueCudaStreamsNoSync()
 DECLARE_UNITTEST(TestUniqueCudaStreamsNoSync);
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__
 void unique_copy_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result1, Iterator3 result2)
@@ -325,7 +325,7 @@ void TestUniqueCopyCudaStreamsNoSync()
 DECLARE_UNITTEST(TestUniqueCopyCudaStreamsNoSync);
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2>
 __global__
 void unique_count_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Iterator2 result)

--- a/testing/cuda/unique_by_key.cu
+++ b/testing/cuda/unique_by_key.cu
@@ -44,6 +44,7 @@ void initialize_values(Vector& values)
 }
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__
 void unique_by_key_kernel(ExecutionPolicy exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 values_first, Iterator3 result)
@@ -139,6 +140,7 @@ void TestUniqueByKeyDeviceNoSync()
   TestUniqueByKeyDevice(thrust::cuda::par_nosync);
 }
 DECLARE_UNITTEST(TestUniqueByKeyDeviceNoSync);
+#endif
 
 
 template<typename ExecutionPolicy>
@@ -210,6 +212,7 @@ void TestUniqueByKeyCudaStreamsNoSync()
 DECLARE_UNITTEST(TestUniqueByKeyCudaStreamsNoSync);
 
 
+#if THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Iterator5>
 __global__
 void unique_by_key_copy_kernel(ExecutionPolicy exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 values_first, Iterator3 keys_result, Iterator4 values_result, Iterator5 result)
@@ -309,6 +312,7 @@ void TestUniqueCopyByKeyDeviceNoSync()
   TestUniqueCopyByKeyDevice(thrust::cuda::par_nosync);
 }
 DECLARE_UNITTEST(TestUniqueCopyByKeyDeviceNoSync);
+#endif
 
 
 template<typename ExecutionPolicy>

--- a/testing/cuda/unique_by_key.cu
+++ b/testing/cuda/unique_by_key.cu
@@ -44,7 +44,7 @@ void initialize_values(Vector& values)
 }
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3>
 __global__
 void unique_by_key_kernel(ExecutionPolicy exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 values_first, Iterator3 result)
@@ -212,7 +212,7 @@ void TestUniqueByKeyCudaStreamsNoSync()
 DECLARE_UNITTEST(TestUniqueByKeyCudaStreamsNoSync);
 
 
-#if THRUST_TEST_DEVICE_SIDE
+#ifdef THRUST_TEST_DEVICE_SIDE
 template<typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Iterator5>
 __global__
 void unique_by_key_copy_kernel(ExecutionPolicy exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 values_first, Iterator3 keys_result, Iterator4 values_result, Iterator5 result)


### PR DESCRIPTION
With this modification, we are able to compile and run most of the tests with Clang CUDA. 