### PR TITLE
Update `sccache` bucket

### DIFF
--- a/ci/axis/cpu.yml
+++ b/ci/axis/cpu.yml
@@ -7,7 +7,7 @@ SDK_TYPE:
   - cuda
 
 SDK_VER:
-  - 11.5.1-devel
+  - 11.5.2-devel
 
 OS_TYPE:
   - ubuntu

--- a/ci/axis/gpu.yml
+++ b/ci/axis/gpu.yml
@@ -7,7 +7,7 @@ SDK_TYPE:
   - cuda
 
 SDK_VER:
-  - 11.5.1-devel
+  - 11.5.2-devel
 
 OS_TYPE:
   - ubuntu

--- a/ci/common/build.bash
+++ b/ci/common/build.bash
@@ -78,8 +78,8 @@ elif [[ "${BUILD_MODE}" == "pull-request" || "${BUILD_MODE}" == "branch" ]]; the
   export ENABLE_SCCACHE="gpuCI"
   # Change to 'thrust-aarch64' if we add aarch64 builds to gpuCI:
   export SCCACHE_S3_KEY_PREFIX=thrust-linux64 # [linux64]
-  export SCCACHE_BUCKET=rapids-sccache
-  export SCCACHE_REGION=us-west-2
+  export SCCACHE_BUCKET=rapids-sccache-east
+  export SCCACHE_REGION=us-east-2
   export SCCACHE_IDLE_TIMEOUT=32768
 else
   export ENABLE_SCCACHE="local"


### PR DESCRIPTION
This PR updates the `sccache` configuration settings to use a new bucket, `rapids-sccache-east`.

Unlike the previous `rapids-sccache` bucket, `rapids-sccache-east` resides in the same AWS region as the rest of our CI infrastructure (`us-east-2`).

This should result in faster, more reliable `sccache` connections and will also help keep our data transfer costs down.

Additionally, this PR updates the `SDK_VER` value to match the current value used by `cccl` below. This will ensure that `thrust` is always using the latest `cccl` images.

- https://github.com/NVIDIA/cccl/blob/a5b457865c780b274837325ad749324331d312fe/ci/axis/docker.yml#L20

This PR depends on https://github.com/NVIDIA/cccl/pull/19.