### PR TITLE
Fix scan for const ref accumulators

### DIFF
--- a/testing/cuda/transform_scan.cu
+++ b/testing/cuda/transform_scan.cu
@@ -186,3 +186,30 @@ void TestTransformScanCudaStreams()
 }
 DECLARE_UNITTEST(TestTransformScanCudaStreams);
 
+void TestTransformScanConstAccumulator()
+{
+  typedef thrust::device_vector<int> Vector;
+  typedef Vector::value_type T;
+
+  Vector::iterator iter;
+
+  Vector input(5);
+  Vector reference(5);
+  Vector output(5);
+
+  input[0] = 1;
+  input[1] = 3;
+  input[2] = -2;
+  input[3] = 4;
+  input[4] = -5;
+
+  thrust::transform_inclusive_scan(input.begin(),
+                                   input.end(),
+                                   output.begin(),
+                                   thrust::identity<T>(),
+                                   thrust::plus<T>());
+  thrust::inclusive_scan(input.begin(), input.end(), reference.begin(), thrust::plus<T>());
+
+  ASSERT_EQUAL(output, reference);
+}
+DECLARE_UNITTEST(TestTransformScanConstAccumulator);

--- a/testing/scan.cu
+++ b/testing/scan.cu
@@ -575,6 +575,55 @@ void TestInclusiveScanWithIndirection(void)
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestInclusiveScanWithIndirection);
 
+template <typename T>
+struct const_ref_plus_mod3
+{
+    T * table;
+
+    const_ref_plus_mod3(T * table) : table(table) {}
+
+    __host__ __device__
+    const T& operator()(T a, T b)
+    {
+        return table[(int) (a + b)];
+    }
+};
+
+template <typename Vector>
+void TestInclusiveScanWithConstAccumulator(void)
+{
+    // add numbers modulo 3 with external lookup table
+    typedef typename Vector::value_type T;
+
+    Vector data(7);
+    data[0] = 0;
+    data[1] = 1;
+    data[2] = 2;
+    data[3] = 1;
+    data[4] = 2;
+    data[5] = 0;
+    data[6] = 1;
+
+    Vector table(6);
+    table[0] = 0;
+    table[1] = 1;
+    table[2] = 2;
+    table[3] = 0;
+    table[4] = 1;
+    table[5] = 2;
+
+    thrust::inclusive_scan(data.begin(), data.end(), data.begin(), const_ref_plus_mod3<T>(thrust::raw_pointer_cast(&table[0])));
+    
+    ASSERT_EQUAL(data[0], T(0));
+    ASSERT_EQUAL(data[1], T(1));
+    ASSERT_EQUAL(data[2], T(0));
+    ASSERT_EQUAL(data[3], T(1));
+    ASSERT_EQUAL(data[4], T(0));
+    ASSERT_EQUAL(data[5], T(0));
+    ASSERT_EQUAL(data[6], T(1));
+}
+DECLARE_INTEGRAL_VECTOR_UNITTEST(TestInclusiveScanWithConstAccumulator);
+
 struct only_set_when_expected_it
 {
     long long expected;

--- a/thrust/iterator/detail/transform_iterator.inl
+++ b/thrust/iterator/detail/transform_iterator.inl
@@ -17,12 +17,12 @@
 #pragma once
 
 #include <thrust/detail/config.h>
-
-#include <thrust/iterator/transform_iterator.h>
-#include <thrust/iterator/iterator_adaptor.h>
-#include <thrust/iterator/iterator_traits.h>
 #include <thrust/detail/type_traits.h>
 #include <thrust/detail/type_traits/result_of_adaptable_function.h>
+#include <thrust/iterator/iterator_adaptor.h>
+#include <thrust/iterator/iterator_traits.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/type_traits/remove_cvref.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -43,22 +43,16 @@ struct transform_iterator_base
       thrust::detail::result_of_adaptable_function<UnaryFunc(typename thrust::iterator_value<Iterator>::type)>
     >::type reference;
 
-    // To get the default for Value: remove any reference on the
-    // result type, but retain any constness to signal
-    // non-writability.  Note that if we adopt Thomas' suggestion
-    // to key non-writability *only* on the Reference argument,
-    // we'd need to strip constness here as well.
-    typedef typename thrust::detail::ia_dflt_help<
-      Value,
-      thrust::detail::remove_reference<reference>
-    >::type cv_value_type;
+    // To get the default for Value: remove cvref on the result type.
+    using value_type =
+      typename thrust::detail::ia_dflt_help<Value, thrust::remove_cvref<reference>>::type;
 
- public:
+  public:
     typedef thrust::iterator_adaptor
     <
         transform_iterator<UnaryFunc, Iterator, Reference, Value>
       , Iterator
-      , cv_value_type
+      , value_type
       , thrust::use_default   // Leave the system alone
         //, thrust::use_default   // Leave the traversal alone
         // use the Iterator's category to let any system iterators remain random access even though

--- a/thrust/system/cuda/detail/transform_scan.h
+++ b/thrust/system/cuda/detail/transform_scan.h
@@ -54,7 +54,7 @@ transform_inclusive_scan(execution_policy<Derived> &policy,
   // Use the transformed input iterator's value type per https://wg21.link/P0571
   using input_type = typename thrust::iterator_value<InputIt>::type;
   using result_type = thrust::detail::invoke_result_t<TransformOp, input_type>;
-  using value_type = typename std::remove_reference<result_type>::type;
+  using value_type = thrust::remove_cvref_t<result_type>;
 
   typedef typename iterator_traits<InputIt>::difference_type size_type;
   size_type num_items = static_cast<size_type>(thrust::distance(first, last));
@@ -86,7 +86,7 @@ transform_exclusive_scan(execution_policy<Derived> &policy,
                          ScanOp                     scan_op)
 {
   // Use the initial value type per https://wg21.link/P0571
-  using result_type = typename std::remove_reference<InitialValueType>::type;
+  using result_type = thrust::remove_cvref_t<InitialValueType>;
 
   typedef typename iterator_traits<InputIt>::difference_type size_type;
   size_type num_items = static_cast<size_type>(thrust::distance(first, last));

--- a/thrust/system/detail/generic/transform_scan.inl
+++ b/thrust/system/detail/generic/transform_scan.inl
@@ -18,12 +18,13 @@
 #pragma once
 
 #include <thrust/detail/config.h>
-#include <thrust/system/detail/generic/transform_scan.h>
-#include <thrust/scan.h>
-#include <thrust/iterator/transform_iterator.h>
 #include <thrust/detail/type_traits.h>
 #include <thrust/detail/type_traits/function_traits.h>
 #include <thrust/detail/type_traits/iterator/is_output_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/scan.h>
+#include <thrust/system/detail/generic/transform_scan.h>
+#include <thrust/type_traits/remove_cvref.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system
@@ -50,7 +51,7 @@ __host__ __device__
   // Use the input iterator's value type per https://wg21.link/P0571
   using InputType = typename thrust::iterator_value<InputIterator>::type;
   using ResultType = thrust::detail::invoke_result_t<UnaryFunction, InputType>;
-  using ValueType = typename std::remove_reference<ResultType>::type;
+  using ValueType = thrust::remove_cvref_t<ResultType>;
 
   thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _first(first, unary_op);
   thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _last(last, unary_op);
@@ -75,7 +76,7 @@ __host__ __device__
                                           AssociativeOperator binary_op)
 {
   // Use the initial value type per https://wg21.link/P0571
-  using ValueType = typename std::remove_reference<InitialValueType>::type;
+  using ValueType = thrust::remove_cvref_t<InitialValueType>;
 
   thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _first(first, unary_op);
   thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _last(last, unary_op);


### PR DESCRIPTION
This PR addresses the following [issue](https://github.com/NVIDIA/thrust/issues/1506) by making Thrust scan work with operators returning constant references. 