### PR TITLE
Stop using `operator[]` on iterators in `for_each[_n]`

### DIFF
--- a/thrust/system/cuda/detail/for_each.h
+++ b/thrust/system/cuda/detail/for_each.h
@@ -55,7 +55,7 @@ namespace cuda_cub {
     template <class Size>
     THRUST_DEVICE_FUNCTION void operator()(Size idx)
     {
-      op(raw_reference_cast(input[idx]));
+      op(raw_reference_cast(*(input + idx)));
     }
   };
 


### PR DESCRIPTION
Too much code in Thrust assumes that `it[n]` returns the same type as `*(it+n)`, but the standard only requires that `it[n]` is convertible to the type of `*(it+n)`. Thrust should avoid using `operator[]` on iterators and prefer instead to use addition/dereference.

Fixes #1452