### PR TITLE
Add missing #include <exception>

### DIFF
--- a/thrust/system/cuda/detail/util.h
+++ b/thrust/system/cuda/detail/util.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <cstdio>
+#include <exception>
 #include <thrust/detail/config.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/cuda/detail/execution_policy.h>


### PR DESCRIPTION
#include <exception> is needed, for example, for std::terminate(). This symbol was likely exported by other standard library headers, but a recent change to LLVM libc++ (https://reviews.llvm.org/D146097) removed some transitive includes of <exception>.