### PR TITLE
Add missing execution space specifiers to vectors

### DIFF
--- a/testing/cuda/device_side_universal_vector.cu
+++ b/testing/cuda/device_side_universal_vector.cu
@@ -1,0 +1,84 @@
+#include <thrust/universal_vector.h>
+
+#include <unittest/unittest.h>
+
+template <class VecT>
+__host__ __device__ void universal_vector_access(VecT &in, thrust::universal_vector<bool> &out)
+{
+  const int expected_front  = 4;
+  const int expected_back   = 2;
+
+  out[0] = in.size() == 2 &&               //
+           in[0] == expected_front &&      //
+           in.front() == expected_front && //
+           *in.data() == expected_front && //
+           in[1] == expected_back &&       //
+           in.back() == expected_back;
+}
+
+#if defined(THRUST_TEST_DEVICE_SIDE)
+template <class VecT>
+__global__ void universal_vector_device_access_kernel(VecT &vec,
+                                                      thrust::universal_vector<bool> &out)
+{
+  universal_vector_access(vec, out);
+}
+
+template <class VecT>
+void test_universal_vector_access(VecT &vec, thrust::universal_vector<bool> &out)
+{
+  universal_vector_device_access_kernel<<<1, 1>>>(vec, out);
+  cudaError_t const err = cudaDeviceSynchronize();
+  ASSERT_EQUAL(cudaSuccess, err);
+  ASSERT_EQUAL(out[0], true);
+}
+#else
+template <class VecT>
+void test_universal_vector_access(VecT &vec, thrust::universal_vector<bool> &out)
+{
+  universal_vector_access(vec, out);
+  ASSERT_EQUAL(out[0], true);
+}
+#endif
+
+void TestUniversalVectorDeviceAccess()
+{
+  thrust::universal_vector<thrust::universal_vector<int>> in_storage(1);
+  thrust::universal_vector<int> &in = *thrust::raw_pointer_cast(in_storage.data());
+
+  in.resize(2);
+  in[0] = 4;
+  in[1] = 2;
+
+  thrust::universal_vector<thrust::universal_vector<bool>> out_storage(1);
+  thrust::universal_vector<bool> &out = *thrust::raw_pointer_cast(out_storage.data());
+  out.resize(1);
+  out[0] = false;
+
+  test_universal_vector_access(in, out);
+}
+DECLARE_UNITTEST(TestUniversalVectorDeviceAccess);
+
+void TestConstUniversalVectorDeviceAccess()
+{
+  thrust::universal_vector<thrust::universal_vector<int>> in_storage(1);
+
+  {
+    thrust::universal_vector<int> &in = *thrust::raw_pointer_cast(in_storage.data());
+
+    in.resize(2);
+    in[0] = 4;
+    in[1] = 2;
+  }
+
+  const thrust::universal_vector<int> &in = *thrust::raw_pointer_cast(in_storage.data());
+
+  thrust::universal_vector<thrust::universal_vector<bool>> out_storage(1);
+  thrust::universal_vector<bool> &out = *thrust::raw_pointer_cast(out_storage.data());
+
+  out.resize(1);
+  out[0] = false;
+
+  test_universal_vector_access(in, out);
+}
+DECLARE_UNITTEST(TestConstUniversalVectorDeviceAccess);

--- a/thrust/detail/vector_base.h
+++ b/thrust/detail/vector_base.h
@@ -222,11 +222,13 @@ template<typename T, typename Alloc>
 
     /*! Returns the number of elements in this vector_base.
      */
+    __host__ __device__
     size_type size(void) const;
 
     /*! Returns the size() of the largest possible vector_base.
      *  \return The largest possible return value of size().
      */
+    __host__ __device__
     size_type max_size(void) const;
 
     /*! \brief If n is less than or equal to capacity(), this call has no effect.
@@ -240,6 +242,7 @@ template<typename T, typename Alloc>
     /*! Returns the number of elements which have been reserved in this
      *  vector_base.
      */
+    __host__ __device__
     size_type capacity(void) const;
 
     /*! This method shrinks the capacity of this vector_base to exactly
@@ -255,6 +258,7 @@ template<typename T, typename Alloc>
      *  Note that data access with this operator is unchecked and
      *  out_of_range lookups are not defined.
      */
+    __host__ __device__
     reference operator[](size_type n);
 
     /*! \brief Subscript read access to the data contained in this vector_dev.
@@ -265,24 +269,28 @@ template<typename T, typename Alloc>
      *  Note that data access with this operator is unchecked and
      *  out_of_range lookups are not defined.
      */
+    __host__ __device__
     const_reference operator[](size_type n) const;
 
     /*! This method returns an iterator pointing to the beginning of
      *  this vector_base.
      *  \return mStart
      */
+    __host__ __device__
     iterator begin(void);
 
     /*! This method returns a const_iterator pointing to the beginning
      *  of this vector_base.
      *  \return mStart
      */
+    __host__ __device__
     const_iterator begin(void) const;
 
     /*! This method returns a const_iterator pointing to the beginning
      *  of this vector_base.
      *  \return mStart
      */
+    __host__ __device__
     const_iterator cbegin(void) const;
 
     /*! This method returns a reverse_iterator pointing to the beginning of
@@ -290,6 +298,7 @@ template<typename T, typename Alloc>
      *  \return A reverse_iterator pointing to the beginning of this
      *          vector_base's reversed sequence.
      */
+    __host__ __device__
     reverse_iterator rbegin(void);
 
     /*! This method returns a const_reverse_iterator pointing to the beginning of
@@ -297,6 +306,7 @@ template<typename T, typename Alloc>
      *  \return A const_reverse_iterator pointing to the beginning of this
      *          vector_base's reversed sequence.
      */
+    __host__ __device__
     const_reverse_iterator rbegin(void) const;
 
     /*! This method returns a const_reverse_iterator pointing to the beginning of
@@ -304,76 +314,89 @@ template<typename T, typename Alloc>
      *  \return A const_reverse_iterator pointing to the beginning of this
      *          vector_base's reversed sequence.
      */
+    __host__ __device__
     const_reverse_iterator crbegin(void) const;
 
     /*! This method returns an iterator pointing to one element past the
      *  last of this vector_base.
      *  \return begin() + size().
      */
+    __host__ __device__
     iterator end(void);
 
     /*! This method returns a const_iterator pointing to one element past the
      *  last of this vector_base.
      *  \return begin() + size().
      */
+    __host__ __device__
     const_iterator end(void) const;
 
     /*! This method returns a const_iterator pointing to one element past the
      *  last of this vector_base.
      *  \return begin() + size().
      */
+    __host__ __device__
     const_iterator cend(void) const;
 
     /*! This method returns a reverse_iterator pointing to one element past the
      *  last of this vector_base's reversed sequence.
      *  \return rbegin() + size().
      */
+    __host__ __device__
     reverse_iterator rend(void);
 
     /*! This method returns a const_reverse_iterator pointing to one element past the
      *  last of this vector_base's reversed sequence.
      *  \return rbegin() + size().
      */
+    __host__ __device__
     const_reverse_iterator rend(void) const;
 
     /*! This method returns a const_reverse_iterator pointing to one element past the
      *  last of this vector_base's reversed sequence.
      *  \return rbegin() + size().
      */
+    __host__ __device__
     const_reverse_iterator crend(void) const;
 
     /*! This method returns a const_reference referring to the first element of this
      *  vector_base.
      *  \return The first element of this vector_base.
      */
+    __host__ __device__
     const_reference front(void) const;
 
     /*! This method returns a reference pointing to the first element of this
      *  vector_base.
      *  \return The first element of this vector_base.
      */
+    __host__ __device__
     reference front(void);
 
     /*! This method returns a const reference pointing to the last element of
      *  this vector_base.
      *  \return The last element of this vector_base.
      */
+    __host__ __device__
     const_reference back(void) const;
 
     /*! This method returns a reference referring to the last element of
      *  this vector_dev.
      *  \return The last element of this vector_base.
      */
+    __host__ __device__
     reference back(void);
 
     /*! This method returns a pointer to this vector_base's first element.
      *  \return A pointer to the first element of this vector_base.
      */
+    __host__ __device__
     pointer data(void);
 
     /*! This method returns a const_pointer to this vector_base's first element.
      *  \return a const_pointer to the first element of this vector_base.
      */
+    __host__ __device__
     const_pointer data(void) const;
 
     /*! This method resizes this vector_base to 0.
@@ -383,6 +406,7 @@ template<typename T, typename Alloc>
     /*! This method returns true iff size() == 0.
      *  \return true if size() == 0; false, otherwise.
      */
+    __host__ __device__
     bool empty(void) const;
 
     /*! This method appends the given element to the end of this vector_base.

--- a/thrust/detail/vector_base.inl
+++ b/thrust/detail/vector_base.inl
@@ -367,6 +367,7 @@ template<typename T, typename Alloc>
 } // end vector_base::resize()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::size_type
     vector_base<T,Alloc>
       ::size(void) const
@@ -375,6 +376,7 @@ template<typename T, typename Alloc>
 } // end vector_base::size()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::size_type
     vector_base<T,Alloc>
       ::max_size(void) const
@@ -424,6 +426,7 @@ template<typename T, typename Alloc>
 } // end vector_base::reserve()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::size_type
     vector_base<T,Alloc>
       ::capacity(void) const
@@ -440,6 +443,7 @@ template<typename T, typename Alloc>
 } // end vector_base::shrink_to_fit()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::reference
     vector_base<T,Alloc>
       ::operator[](const size_type n)
@@ -448,6 +452,7 @@ template<typename T, typename Alloc>
 } // end vector_base::operator[]
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::const_reference
     vector_base<T,Alloc>
       ::operator[](const size_type n) const
@@ -456,6 +461,7 @@ template<typename T, typename Alloc>
 } // end vector_base::operator[]
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::iterator
     vector_base<T,Alloc>
       ::begin(void)
@@ -464,6 +470,7 @@ template<typename T, typename Alloc>
 } // end vector_base::begin()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::const_iterator
     vector_base<T,Alloc>
       ::begin(void) const
@@ -472,6 +479,7 @@ template<typename T, typename Alloc>
 } // end vector_base::begin()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::const_iterator
     vector_base<T,Alloc>
       ::cbegin(void) const
@@ -480,6 +488,7 @@ template<typename T, typename Alloc>
 } // end vector_base::cbegin()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::reverse_iterator
     vector_base<T,Alloc>
       ::rbegin(void)
@@ -488,6 +497,7 @@ template<typename T, typename Alloc>
 } // end vector_base::rbegin()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::const_reverse_iterator
     vector_base<T,Alloc>
       ::rbegin(void) const
@@ -496,6 +506,7 @@ template<typename T, typename Alloc>
 } // end vector_base::rbegin()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::const_reverse_iterator
     vector_base<T,Alloc>
       ::crbegin(void) const
@@ -504,6 +515,7 @@ template<typename T, typename Alloc>
 } // end vector_base::crbegin()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::iterator
     vector_base<T,Alloc>
       ::end(void)
@@ -514,6 +526,7 @@ template<typename T, typename Alloc>
 } // end vector_base::end()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::const_iterator
     vector_base<T,Alloc>
       ::end(void) const
@@ -524,6 +537,7 @@ template<typename T, typename Alloc>
 } // end vector_base::end()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::const_iterator
     vector_base<T,Alloc>
       ::cend(void) const
@@ -532,6 +546,7 @@ template<typename T, typename Alloc>
 } // end vector_base::cend()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::reverse_iterator
     vector_base<T,Alloc>
       ::rend(void)
@@ -540,6 +555,7 @@ template<typename T, typename Alloc>
 } // end vector_base::rend()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::const_reverse_iterator
     vector_base<T,Alloc>
       ::rend(void) const
@@ -548,6 +564,7 @@ template<typename T, typename Alloc>
 } // end vector_base::rend()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::const_reverse_iterator
     vector_base<T,Alloc>
       ::crend(void) const
@@ -556,6 +573,7 @@ template<typename T, typename Alloc>
 } // end vector_base::crend()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::const_reference
     vector_base<T,Alloc>
       ::front(void) const
@@ -564,6 +582,7 @@ template<typename T, typename Alloc>
 } // end vector_base::front()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::reference
     vector_base<T,Alloc>
       ::front(void)
@@ -572,6 +591,7 @@ template<typename T, typename Alloc>
 } // end vector_base::front()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::const_reference
     vector_base<T,Alloc>
       ::back(void) const
@@ -582,6 +602,7 @@ template<typename T, typename Alloc>
 } // end vector_base::vector_base
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::reference
     vector_base<T,Alloc>
       ::back(void)
@@ -592,6 +613,7 @@ template<typename T, typename Alloc>
 } // end vector_base::vector_base
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::pointer
     vector_base<T,Alloc>
       ::data(void)
@@ -600,6 +622,7 @@ template<typename T, typename Alloc>
 } // end vector_base::data()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   typename vector_base<T,Alloc>::const_pointer
     vector_base<T,Alloc>
       ::data(void) const
@@ -624,6 +647,7 @@ template<typename T, typename Alloc>
 } // end vector_base::~vector_dev()
 
 template<typename T, typename Alloc>
+  __host__ __device__
   bool vector_base<T,Alloc>
     ::empty(void) const
 {


### PR DESCRIPTION
Currently, `vector_base` is missing execution space specifiers, which prevents users from referencing `universal_vector` from device. This PR adds execution space specifiers to some methods that are thing wrappers over `contiguous_storage` methods, which already have execution space specifiers. 