### PR TITLE
Update optional.h

### DIFF
--- a/thrust/optional.h
+++ b/thrust/optional.h
@@ -117,7 +117,7 @@ THRUST_NAMESPACE_END
 
 #if defined(__GLIBCXX__) && __has_feature(is_trivially_assignable)
 #define THRUST_OPTIONAL_IS_TRIVIALLY_COPY_ASSIGNABLE(T) \
-  __is_trivially_assignable(T, T const&)
+  __is_trivially_assignable(T&, T const&)
 #else
 #define THRUST_OPTIONAL_IS_TRIVIALLY_COPY_ASSIGNABLE(T) \
   std::is_trivially_copy_assignable<T>::value
@@ -133,7 +133,7 @@ THRUST_NAMESPACE_END
 
 #if defined(__GLIBCXX__) && __has_feature(is_trivially_assignable)
 #define THRUST_OPTIONAL_IS_TRIVIALLY_MOVE_ASSIGNABLE(T) \
-  __is_trivially_assignable(T, T&&)
+  __is_trivially_assignable(T&, T&&)
 #else
 #define THRUST_OPTIONAL_IS_TRIVIALLY_MOVE_ASSIGNABLE(T) \
   std::is_trivially_move_assignable<T>::value


### PR DESCRIPTION
in c++, __is_trivially_assignable(T, T const&) and __is_trivially_assignable(T, T &&) are not assignable, not suitable for copy assignable and move assignable. this issue is exposed in the following compile command line "nvcc --ccbin=/usr/bin/clang test.cu -o test.o"

the discussion thread is at https://github.com/NVIDIA/thrust/issues/1921